### PR TITLE
Support crater runs on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,12 +18,14 @@ install:
   - rustc -V
   - cargo -V
 
-build: false
-
 branches:
   only:
     - auto
     - try
+    - master
+
+build_script:
+  - cargo build
 
 test_script:
-  - cargo build
+  - cargo test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,4 +28,5 @@ build_script:
   - cargo build
 
 test_script:
+  - cargo run -- create-lists
   - cargo test

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.md text eol=lf
 *.gitignore text eol=lf
 *.gitattributes text eol=lf
+*.json text eol=lf

--- a/docs/agent-machine-setup-windows.md
+++ b/docs/agent-machine-setup-windows.md
@@ -119,20 +119,4 @@ cargo build --release
 cargo run --release -- prepare-local
 ```
 
-Running `minicrater` tests require that the `*.expected.json` files match the
-output of crater exactly. However, when installed via `chocolately`, `git` has
-config `core.autocrlf` set to `true` by default. This will override the
-preferences in `crater`'s `.gitattributes` file and cause the JSON files to
-have the wrong line endings (CRLF). Make sure you set `core.autocrlf = false`
-before cloning the repo.
-
-If you've already cloned the repo, simply run the following from inside of it
-to replace the JSON files:
-
-```powershell
-git config core.autocrlf false
-rm -r tests/
-git checkout -- tests/
-```
-
 Remember to run `cargo run -- create-lists` before running the tests.

--- a/docs/agent-machine-setup-windows.md
+++ b/docs/agent-machine-setup-windows.md
@@ -120,3 +120,14 @@ cargo run --release -- prepare-local
 ```
 
 Remember to run `cargo run -- create-lists` before running the tests.
+
+# Troubleshooting
+
+## Overlong paths
+
+If you encounter warnings about paths being too long, you should disable the
+260 character limit. This option is called "Enable Win32 long paths" in the
+policy editor. See this [Stack Overflow question][so-long-path] for more
+details.
+
+[so-long-path]: https://superuser.com/questions/1119883/windows-10-enable-ntfs-long-paths-policy-option-missing

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,10 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use structopt::clap::AppSettings;
 
+#[cfg(windows)]
+static DEFAULT_DOCKER_ENV: &str = "rustops/crates-build-env-windows";
+
+#[cfg(not(windows))]
 static DEFAULT_DOCKER_ENV: &str = "rustops/crates-build-env";
 
 // An experiment name

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -4,7 +4,7 @@ mod sources;
 use crate::dirs::LOCAL_CRATES_DIR;
 use crate::prelude::*;
 use std::fmt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 pub(crate) use crate::crates::sources::github::GitHubRepo;
@@ -24,6 +24,16 @@ impl Crate {
             Crate::GitHub(ref repo) => format!("gh/{}/{}", repo.org, repo.name),
             Crate::Local(ref name) => format!("local/{}", name),
         }
+    }
+
+    pub(crate) fn to_path(&self) -> PathBuf {
+        let components: Vec<&str> = match *self {
+            Crate::Registry(ref details) => vec!["reg", &details.name, &details.version],
+            Crate::GitHub(ref repo) => vec!["gh", &repo.org, &repo.name],
+            Crate::Local(ref name) => vec!["local", &name],
+        };
+
+        components.into_iter().collect()
     }
 
     pub(crate) fn fetch(&self) -> Fallible<()> {

--- a/src/crates/sources/registry.rs
+++ b/src/crates/sources/registry.rs
@@ -20,6 +20,7 @@ impl List for RegistryList {
         let mut list = Vec::new();
         let mut counts = HashMap::new();
 
+        fs::create_dir_all(&*LOCAL_DIR)?;
         let index = Index::new(LOCAL_DIR.join("crates.io-index"));
         index.retrieve_or_update().to_failure()?;
 

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -44,7 +44,7 @@ pub(crate) fn crate_source_dir(ex: &Experiment, tc: &Toolchain, krate: &Crate) -
         .join(&ex.name)
         .join("sources")
         .join(tc.to_path_component())
-        .join(krate.id())
+        .join(krate.to_path())
 }
 
 pub mod container {

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -46,3 +46,27 @@ pub(crate) fn crate_source_dir(ex: &Experiment, tc: &Toolchain, krate: &Crate) -
         .join(tc.to_path_component())
         .join(krate.id())
 }
+
+pub mod container {
+    use std::path::{Path, PathBuf};
+
+    use lazy_static::lazy_static;
+
+    #[cfg(windows)]
+    lazy_static! {
+        pub static ref ROOT_DIR: PathBuf = Path::new(r"C:\crater").into();
+    }
+
+    #[cfg(not(windows))]
+    lazy_static! {
+        pub static ref ROOT_DIR: PathBuf = Path::new("/opt/crater").into();
+    }
+
+    lazy_static! {
+        pub static ref WORK_DIR: PathBuf = ROOT_DIR.join("workdir");
+        pub static ref TARGET_DIR: PathBuf = ROOT_DIR.join("target");
+        pub static ref CARGO_HOME: PathBuf = ROOT_DIR.join("cargo-home");
+        pub static ref RUSTUP_HOME: PathBuf = ROOT_DIR.join("rustup-home");
+        pub static ref CARGO_BIN_DIR: PathBuf = CARGO_HOME.join("bin");
+    }
+}

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -194,6 +194,10 @@ impl<'a> ContainerBuilder<'a> {
             args.push("none".into());
         }
 
+        if cfg!(windows) {
+            args.push("--isolation=process".into());
+        }
+
         args.push(self.image.image.clone());
 
         for arg in self.cmd {

--- a/src/native/unix.rs
+++ b/src/native/unix.rs
@@ -14,8 +14,8 @@ pub(crate) fn kill_process(id: u32) -> Fallible<()> {
     Ok(())
 }
 
-pub(crate) fn current_user() -> u32 {
-    Uid::effective().into()
+pub(crate) fn current_user() -> Option<u32> {
+    Some(Uid::effective().into())
 }
 
 fn current_group() -> u32 {
@@ -25,7 +25,7 @@ fn current_group() -> u32 {
 fn executable_mode_for(path: &Path) -> Fallible<u32> {
     let metadata = path.metadata()?;
 
-    if metadata.uid() == current_user() {
+    if metadata.uid() == current_user().unwrap() {
         Ok(EXECUTABLE_BITS << 6)
     } else if metadata.gid() == current_group() {
         Ok(EXECUTABLE_BITS << 3)
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_current_user() {
-        assert_eq!(current_user(), u32::from(Uid::effective()));
+        assert_eq!(current_user(), Some(u32::from(Uid::effective())));
     }
 
     #[test]

--- a/src/report/archives.rs
+++ b/src/report/archives.rs
@@ -51,7 +51,12 @@ pub fn write_logs_archives<DB: ReadResults, W: ReportWriter>(
             let log_bytes = log_bytes.to_plain()?;
             let log_bytes = log_bytes.as_slice();
 
-            let path = format!("{}/{}/{}.txt", comparison, krate.id(), tc);
+            let path = format!(
+                "{}/{}/{}.txt",
+                comparison,
+                krate.id(),
+                tc.to_path_component(),
+            );
 
             let mut header = TarHeader::new_gnu();
             header.set_size(log_bytes.len() as u64);

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -145,7 +145,7 @@ pub fn generate_report<DB: ReadResults>(
                     log: crate_to_path_fragment(tc, &krate, true)
                         .to_str()
                         .unwrap()
-                        .to_string(),
+                        .replace(r"\", "/"),
                 })
             });
             // Convert errors to Nones

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -28,11 +28,6 @@ url::define_encode_set! {
     pub REPORT_ENCODE_SET = [DEFAULT_ENCODE_SET] | { '+' }
 }
 
-#[inline]
-fn url_encode(input: &str) -> String {
-    utf8_percent_encode(input, REPORT_ENCODE_SET).to_string()
-}
-
 #[derive(Serialize, Deserialize)]
 pub struct TestResults {
     pub crates: Vec<CrateResult>,
@@ -86,34 +81,45 @@ struct BuildTestResult {
     log: String,
 }
 
-fn crate_to_path_fragment(toolchain: &Toolchain, krate: &Crate, encode: bool) -> PathBuf {
-    let mut path = PathBuf::new();
-    if encode {
-        path.push(url_encode(&toolchain.to_string()));
-    } else {
-        path.push(toolchain.to_string());
+/// The type of sanitization required for a string.
+#[derive(Debug, Clone, Copy)]
+enum SanitizationContext {
+    Url,
+    Path,
+}
+
+impl SanitizationContext {
+    fn sanitize(self, input: &str) -> Cow<str> {
+        match self {
+            SanitizationContext::Url => utf8_percent_encode(input, REPORT_ENCODE_SET).into(),
+
+            SanitizationContext::Path => {
+                utf8_percent_encode(input, utils::fs::FILENAME_ENCODE_SET).into()
+            }
+        }
     }
+}
+
+fn crate_to_path_fragment(
+    toolchain: &Toolchain,
+    krate: &Crate,
+    dest: SanitizationContext,
+) -> PathBuf {
+    let mut path = PathBuf::new();
+    path.push(dest.sanitize(&toolchain.to_string()).into_owned());
 
     match *krate {
         Crate::Registry(ref details) => {
             path.push("reg");
 
             let name = format!("{}-{}", details.name, details.version);
-            if encode {
-                path.push(url_encode(&name));
-            } else {
-                path.push(name);
-            }
+            path.push(dest.sanitize(&name).into_owned());
         }
         Crate::GitHub(ref repo) => {
             path.push("gh");
 
             let name = format!("{}.{}", repo.org, repo.name);
-            if encode {
-                path.push(url_encode(&name));
-            } else {
-                path.push(name);
-            }
+            path.push(dest.sanitize(&name).into_owned());
         }
         Crate::Local(ref name) => {
             path.push("local");
@@ -142,10 +148,10 @@ pub fn generate_report<DB: ReadResults>(
 
                 Ok(BuildTestResult {
                     res,
-                    log: crate_to_path_fragment(tc, &krate, true)
+                    log: crate_to_path_fragment(tc, &krate, SanitizationContext::Url)
                         .to_str()
                         .unwrap()
-                        .replace(r"\", "/"),
+                        .replace(r"\", "/"), // Normalize paths in reports generated on Windows
                 })
             });
             // Convert errors to Nones
@@ -192,7 +198,8 @@ fn write_logs<DB: ReadResults, W: ReportWriter>(
         }
 
         for tc in &ex.toolchains {
-            let log_path = crate_to_path_fragment(tc, krate, false).join("log.txt");
+            let log_path =
+                crate_to_path_fragment(tc, krate, SanitizationContext::Path).join("log.txt");
             let content = db
                 .load_log(ex, tc, krate)
                 .and_then(|c| c.ok_or_else(|| err_msg("missing logs")))
@@ -486,26 +493,26 @@ mod tests {
             org: "brson".into(),
             name: "hello-rs".into(),
         });
-        let plus = Crate::Registry(RegistryCrate {
+        let gt_plus = Crate::Registry(RegistryCrate {
             name: "foo".into(),
-            version: "1.0+bar".into(),
+            version: ">1.0+bar".into(),
         });
 
         assert_eq!(
-            crate_to_path_fragment(&MAIN_TOOLCHAIN, &reg, false),
+            crate_to_path_fragment(&MAIN_TOOLCHAIN, &reg, SanitizationContext::Path),
             PathBuf::from("stable/reg/lazy_static-1.0")
         );
         assert_eq!(
-            crate_to_path_fragment(&MAIN_TOOLCHAIN, &gh, false),
+            crate_to_path_fragment(&MAIN_TOOLCHAIN, &gh, SanitizationContext::Path),
             PathBuf::from("stable/gh/brson.hello-rs")
         );
         assert_eq!(
-            crate_to_path_fragment(&MAIN_TOOLCHAIN, &plus, false),
-            PathBuf::from("stable/reg/foo-1.0+bar")
+            crate_to_path_fragment(&MAIN_TOOLCHAIN, &gt_plus, SanitizationContext::Path),
+            PathBuf::from("stable/reg/foo-%3E1.0+bar")
         );
         assert_eq!(
-            crate_to_path_fragment(&MAIN_TOOLCHAIN, &plus, true),
-            PathBuf::from("stable/reg/foo-1.0%2Bbar")
+            crate_to_path_fragment(&MAIN_TOOLCHAIN, &gt_plus, SanitizationContext::Url),
+            PathBuf::from("stable/reg/foo-%3E1.0%2Bbar")
         );
     }
 

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -1,3 +1,4 @@
+use crate::dirs;
 use crate::docker::{DockerError, MountPerms};
 use crate::prelude::*;
 use crate::results::{EncodingType, FailureReason, TestResult, WriteResults};
@@ -45,12 +46,19 @@ fn run_cargo<DB: WriteResults>(
         .args(args)
         .quiet(ctx.quiet)
         .cd(source_path)
-        .env("CARGO_TARGET_DIR", "/opt/crater/target")
+        .env(
+            "CARGO_TARGET_DIR",
+            dirs::container::TARGET_DIR.to_str().unwrap(),
+        )
         .env("CARGO_INCREMENTAL", "0")
         .env("RUST_BACKTRACE", "full")
         .env(rustflags_env, rustflags)
         .sandboxed(&ctx.docker_env)
-        .mount(target_dir, "/opt/crater/target", MountPerms::ReadWrite)
+        .mount(
+            target_dir,
+            dirs::container::TARGET_DIR.to_str().unwrap(),
+            MountPerms::ReadWrite,
+        )
         .memory_limit(Some(ctx.config.sandbox.memory_limit))
         .run()?;
 

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -56,7 +56,7 @@ fn run_cargo<DB: WriteResults>(
         .sandboxed(&ctx.docker_env)
         .mount(
             target_dir,
-            dirs::container::TARGET_DIR.to_str().unwrap(),
+            &*dirs::container::TARGET_DIR,
             MountPerms::ReadWrite,
         )
         .memory_limit(Some(ctx.config.sandbox.memory_limit))

--- a/src/server/agents.rs
+++ b/src/server/agents.rs
@@ -210,7 +210,7 @@ mod tests {
         agents.record_heartbeat("agent").unwrap();
 
         let agent = agents.get("agent").unwrap().unwrap();
-        assert!(first_heartbeat < agent.last_heartbeat.unwrap());
+        assert!(first_heartbeat <= agent.last_heartbeat.unwrap());
     }
 
     #[test]

--- a/src/tools/rustup.rs
+++ b/src/tools/rustup.rs
@@ -59,6 +59,8 @@ impl InstallableTool for Rustup {
             native::make_executable(installer)?;
         }
 
+        // TODO(rustup.rs#998): Remove `.quiet(true)` once rust-docs is no longer a mandatory
+        // component.
         RunCommand::new(installer.to_string_lossy().as_ref())
             .args(&[
                 "-y",
@@ -66,6 +68,7 @@ impl InstallableTool for Rustup {
                 "--default-toolchain",
                 MAIN_TOOLCHAIN_NAME,
             ])
+            .quiet(true)
             .local_rustup(true)
             .run()
             .with_context(|_| "unable to install rustup")?;

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -102,3 +102,33 @@ pub(crate) fn copy_dir(src_dir: &Path, dest_dir: &Path) -> Fallible<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+#[cfg(windows)]
+mod tests {
+    use super::*;
+
+    use std::path::Path;
+
+    #[test]
+    fn strip_verbatim() {
+        let suite = vec![
+            (r"C:\Users\carl", None),
+            (r"\Users\carl", None),
+            (r"\\?\C:\Users\carl", Some(r"C:\")),
+            (r"\\?\Users\carl", Some(r"Users")),
+        ];
+
+        for (input, output) in suite {
+            let p = Path::new(input);
+            let first_component = p.components().next().unwrap();
+
+            if let path::Component::Prefix(prefix) = &first_component {
+                let stripped = strip_verbatim_from_prefix(&prefix);
+                assert_eq!(stripped.as_ref().map(|p| p.to_str().unwrap()), output);
+            } else {
+                assert!(output.is_none());
+            }
+        }
+    }
+}

--- a/tests/minicrater/driver.rs
+++ b/tests/minicrater/driver.rs
@@ -145,10 +145,11 @@ impl MinicraterRun {
 
 #[macro_export]
 macro_rules! minicrater {
-    ($($name:ident $opts:tt,)*) => {
+    ($( $(#[$cfg:meta])* $name:ident $opts:tt,)*) => {
         $(
             #[test]
             #[ignore]
+            $(#[$cfg])*
             fn $name() {
                 use $crate::minicrater::driver::MinicraterRun;
                 MinicraterRun $opts.execute();

--- a/tests/minicrater/driver.rs
+++ b/tests/minicrater/driver.rs
@@ -123,8 +123,10 @@ impl MinicraterRun {
             .expect("failed to write copy of the json report");
 
         let changeset = Changeset::new(
-            &String::from_utf8(expected_report).expect("invalid utf-8 in the expected report"),
-            &String::from_utf8(actual_report.clone()).expect("invalid utf-8 in the actual report"),
+            &String::from_utf8(expected_report)
+                .expect("invalid utf-8 in the expected report")
+                .replace("\r\n", "\n"),
+            &String::from_utf8(actual_report).expect("invalid utf-8 in the actual report"),
             "\n",
         );
         if changeset.distance != 0 {

--- a/tests/minicrater/full/results.expected.json
+++ b/tests/minicrater/full/results.expected.json
@@ -91,21 +91,6 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
     },
     {
-      "name": "memory-hungry (local)",
-      "res": "spurious-fixed",
-      "runs": [
-        {
-          "log": "stable/local/memory-hungry",
-          "res": "build-fail:oom"
-        },
-        {
-          "log": "beta/local/memory-hungry",
-          "res": "test-fail:oom"
-        }
-      ],
-      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
-    },
-    {
       "name": "missing-examples (local)",
       "res": "test-pass",
       "runs": [
@@ -179,6 +164,15 @@
         }
       ],
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/yanked-deps"
+    },
+    {
+      "name": "memory-hungry (local)",
+      "res": "skipped",
+      "runs": [
+        null,
+        null
+      ],
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
     }
   ]
 }

--- a/tests/minicrater/mod.rs
+++ b/tests/minicrater/mod.rs
@@ -41,4 +41,11 @@ minicrater! {
         toolchains: &["stable", "stable+rustflags=-Dclippy::all"],
         ..Default::default()
     },
+
+    #[cfg(not(windows))] // `State.OOMKilled` is not set on Windows
+    resource_exhaustion {
+        ex: "resource-exhaustion",
+        crate_select: "demo",
+        ..Default::default()
+    },
 }

--- a/tests/minicrater/resource-exhaustion/config.toml
+++ b/tests/minicrater/resource-exhaustion/config.toml
@@ -10,7 +10,7 @@ experiment-completed = "S-waiting-on-review"
 [demo-crates]
 crates = []
 github-repos = []
-local-crates = []
+local-crates = ["build-pass", "memory-hungry"]
 
 [sandbox]
 memory-limit = "512M"
@@ -22,4 +22,3 @@ build-log-max-lines = 1000
 [github-repos]
 
 [local-crates]
-memory-hungry = { skip = true }

--- a/tests/minicrater/resource-exhaustion/results.expected.json
+++ b/tests/minicrater/resource-exhaustion/results.expected.json
@@ -1,0 +1,34 @@
+{
+  "crates": [
+    {
+      "name": "build-pass (local)",
+      "res": "test-pass",
+      "runs": [
+        {
+          "log": "stable/local/build-pass",
+          "res": "test-pass"
+        },
+        {
+          "log": "beta/local/build-pass",
+          "res": "test-pass"
+        }
+      ],
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
+    },
+    {
+      "name": "memory-hungry (local)",
+      "res": "spurious-fixed",
+      "runs": [
+        {
+          "log": "stable/local/memory-hungry",
+          "res": "build-fail:oom"
+        },
+        {
+          "log": "beta/local/memory-hungry",
+          "res": "test-fail:oom"
+        }
+      ],
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #149.

This allows builds to run on [the newly added docker image](https://github.com/rust-lang/crates-build-env/pull/5). In order to run successfully, you'll need to correctly [configure the Docker host](https://github.com/rust-lang/crater/blob/master/docs/agent-machine-setup-windows.md) ~~and `crater`'s `work` directory should have an ACL to enable full-access by the `"Authenticated Users"` group. This allows the container to write to the newly created `target` directories.~~

~~The changes in the first commit don't belong in the finished product: Windows' permissions are [fundamentally different than the POSIX ones](https://en.wikipedia.org/wiki/Access_control_list) so I need to think more about how to change the current API to be more cross-platform. However, `.exe`s are executable by default on Windows and user remapping isn't done within the container anyways, so my changes were enough to this PR up and running.~~

~~I couldn't get OpenSSL to link properly when building crater on Windows, despite setting `OPENSSL_DIR`, so I've temporarily reverted "switch from ring to openssl" to let me run tests. This should be un-reverted before this is merged.~~

~~The last commit points to a self-published version of the docker image, not a `rust-ops` published one. An official version can be published once I get [CI up and running](https://github.com/rust-lang/crates-build-env/pull/5#issue-252680848) for the Windows image.~~

The concerns listed above have all been resolved. The ACL change seems to have been obsoleted by later versions of Docker on Windows.
