### PR TITLE
Migrate the Crater repository to the main org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,10 @@ unassigned issues in there. There are some labels you can check:
 Please remember to comment on an issue when you start working on it, to avoid
 multiple people working on the same one!
 
-[issues]: https://github.com/rust-lang-nursery/crater/issues
-[issues-easy]: https://github.com/rust-lang-nursery/crater/labels/E-easy
-[issues-mentor]: https://github.com/rust-lang-nursery/crater/labels/E-mentor
-[issues-needs-help]: https://github.com/rust-lang-nursery/crater/labels/E-needs-help
+[issues]: https://github.com/rust-lang/crater/issues
+[issues-easy]: https://github.com/rust-lang/crater/labels/E-easy
+[issues-mentor]: https://github.com/rust-lang/crater/labels/E-mentor
+[issues-needs-help]: https://github.com/rust-lang/crater/labels/E-needs-help
 
 [Go back to the TOC][h-toc]
 
@@ -72,7 +72,7 @@ instance. The full image takes a long time to build (20+ minutes as of October
 You can check out the [CLI Usage][cli-usage] documentation to learn how to
 interact with the Crater CLI.
 
-[win]: https://github.com/rust-lang-nursery/crater/issues/149
+[win]: https://github.com/rust-lang/crater/issues/149
 [cli-usage]: docs/cli-usage.md
 
 [Go back to the TOC][h-toc]
@@ -138,12 +138,12 @@ cargo run -- agent http://127.0.0.1:8000 token
 
 Before submitting your pull request, you need to lint the code in the project, as otherwise the continuous integration builds will fail.
 
-This project makes use of [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt) and [`clippy`](https://github.com/rust-lang-nursery/rust-clippy) to format the code, and catch common mistakes respectively.
+This project makes use of [`rustfmt`](https://github.com/rust-lang/rustfmt) and [`clippy`](https://github.com/rust-lang/rust-clippy) to format the code, and catch common mistakes respectively.
 
 ### Linting your code
-To install rustfmt, you should follow the [quick start instructions](https://github.com/rust-lang-nursery/rustfmt#quick-start) to install it using the [`rustup`](https://rustup.rs/) tool.
+To install rustfmt, you should follow the [quick start instructions](https://github.com/rust-lang/rustfmt#quick-start) to install it using the [`rustup`](https://rustup.rs/) tool.
 
-To install clippy, you should follow the [usage instruction](https://github.com/rust-lang-nursery/rust-clippy#usage) to install it using the [`rustup`](https://rustup.rs/) tool.
+To install clippy, you should follow the [usage instruction](https://github.com/rust-lang/rust-clippy#usage) to install it using the [`rustup`](https://rustup.rs/) tool.
 
 To lint the code, run `cargo fmt` to format your code and `cargo clippy` to catch common mistakes and improve your code.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Crater [![Build Status](https://travis-ci.org/rust-lang-nursery/crater.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/crater)
+# Crater [![Build Status](https://travis-ci.com/rust-lang/crater.svg?branch=master)](https://travis-ci.com/rust-lang/crater)
 
 Crater is a tool to run experiments across parts of the Rust ecosystem. Its
 primary purpose is to detect regressions in the Rust compiler, and it does this

--- a/docs/agent-machine-setup-windows.md
+++ b/docs/agent-machine-setup-windows.md
@@ -111,7 +111,7 @@ The next step is to download and build `crater` just like on a [Linux
 agent](./agent-machine-setup.md):
 
 ```powershell
-git clone https://github.com/rust-lang-nursery/crater
+git clone https://github.com/rust-lang/crater
 cd crater
 cargo build --release
 

--- a/docs/agent-machine-setup.md
+++ b/docs/agent-machine-setup.md
@@ -38,7 +38,7 @@ from an existing agent into the new one, and then log into it again and
 execute:
 
 ```
-git clone https://github.com/rust-lang-nursery/crater
+git clone https://github.com/rust-lang/crater
 cd crater
 cargo build --release
 

--- a/docs/legacy-workflow.md
+++ b/docs/legacy-workflow.md
@@ -141,9 +141,9 @@ the sheet that does not have a status of 'Complete' or 'Failed'.
    - Change status to 'Complete' and add the results link,
      `http://cargobomb-reports.s3.amazonaws.com/EX_NAME/index.html`.
    - Update either the PR or the person requesting the beta run. Template is:
-     > Hi X (crater requester), Y (PR reviewer)! Crater results are at: \<url>. 'Blacklisted' crates (spurious failures etc) can be found \[here\](https://github.com/rust-lang-nursery/crater/blob/master/config.toml). If you see any spurious failures not on the list, please make a PR against that file.
+     > Hi X (crater requester), Y (PR reviewer)! Crater results are at: \<url>. 'Blacklisted' crates (spurious failures etc) can be found \[here\](https://github.com/rust-lang/crater/blob/master/config.toml). If you see any spurious failures not on the list, please make a PR against that file.
      >
-     > (interested observers: Crater is a tool for testing the impact of changes on parts of the Rust ecosystem. You can find out more at the \[repo\](https://github.com/rust-lang-nursery/crater/) if you're curious)
+     > (interested observers: Crater is a tool for testing the impact of changes on parts of the Rust ecosystem. You can find out more at the \[repo\](https://github.com/rust-lang/crater/) if you're curious)
    - Give yourself a pat on the back! Good job!
    - Go to next run.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,4 +33,4 @@ mod tools;
 
 pub(crate) static GIT_REVISION: Option<&str> = include!(concat!(env!("OUT_DIR"), "/sha"));
 pub(crate) static HOST_TARGET: &str = include_str!(concat!(env!("OUT_DIR"), "/target"));
-pub(crate) static CRATER_REPO_URL: &str = "https://github.com/rust-lang-nursery/crater";
+pub(crate) static CRATER_REPO_URL: &str = "https://github.com/rust-lang/crater";

--- a/templates/ui/agents.html
+++ b/templates/ui/agents.html
@@ -37,7 +37,7 @@
                             </td>
                             <td>
                                 {% if agent.git_revision %}
-                                    <a rel="noopener" target="_blank" href="https://github.com/rust-lang-nursery/crater/commit/{{ agent.git_revision }}">
+                                    <a rel="noopener" target="_blank" href="https://github.com/rust-lang/crater/commit/{{ agent.git_revision }}">
                                         {{ agent.git_revision }}
                                     </a>
                                 {% else %}

--- a/templates/ui/layout.html
+++ b/templates/ui/layout.html
@@ -26,7 +26,7 @@
         <footer>
             {% if layout.git_revision %}
                 Crater
-                <a href="https://github.com/rust-lang-nursery/crater/commit/{{ layout.git_revision }}">
+                <a href="https://github.com/rust-lang/crater/commit/{{ layout.git_revision }}">
                     {{ layout.git_revision }}
                 </a>
             {% endif %}

--- a/tests/minicrater/blacklist/results.expected.json
+++ b/tests/minicrater/blacklist/results.expected.json
@@ -13,7 +13,7 @@
           "res": "test-pass"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-pass"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     },
     {
       "name": "test-fail (local)",
@@ -28,7 +28,7 @@
           "res": "test-skipped"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/test-fail"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
     },
     {
       "name": "build-fail (local)",
@@ -37,7 +37,7 @@
         null,
         null
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-fail"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
     }
   ]
 }

--- a/tests/minicrater/clippy/results.expected.json
+++ b/tests/minicrater/clippy/results.expected.json
@@ -13,7 +13,7 @@
           "res": "test-pass"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-pass"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     },
     {
       "name": "clippy-warn (local)",
@@ -28,7 +28,7 @@
           "res": "build-fail:unknown"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/clippy-warn"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
     }
   ]
 }

--- a/tests/minicrater/full/results.expected.json
+++ b/tests/minicrater/full/results.expected.json
@@ -13,7 +13,7 @@
           "res": "test-pass"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/beta-fixed"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-fixed"
     },
     {
       "name": "beta-regression (local)",
@@ -28,7 +28,7 @@
           "res": "build-fail:unknown"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/beta-regression"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
     },
     {
       "name": "broken-cargotoml (local)",
@@ -43,7 +43,7 @@
           "res": "broken:cargo-toml"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/broken-cargotoml"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/broken-cargotoml"
     },
     {
       "name": "build-fail (local)",
@@ -58,7 +58,7 @@
           "res": "build-fail:unknown"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-fail"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
     },
     {
       "name": "build-pass (local)",
@@ -73,7 +73,7 @@
           "res": "test-pass"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-pass"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     },
     {
       "name": "clippy-warn (local)",
@@ -88,7 +88,7 @@
           "res": "test-pass"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/clippy-warn"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
     },
     {
       "name": "memory-hungry (local)",
@@ -103,7 +103,7 @@
           "res": "test-fail:oom"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/memory-hungry"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
     },
     {
       "name": "missing-examples (local)",
@@ -118,7 +118,7 @@
           "res": "test-pass"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/missing-examples"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/missing-examples"
     },
     {
       "name": "network-access (local)",
@@ -133,7 +133,7 @@
           "res": "test-fail:unknown"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/network-access"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/network-access"
     },
     {
       "name": "outdated-lockfile (local)",
@@ -148,7 +148,7 @@
           "res": "test-pass"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/outdated-lockfile"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/outdated-lockfile"
     },
     {
       "name": "test-fail (local)",
@@ -163,7 +163,7 @@
           "res": "test-fail:unknown"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/test-fail"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
     },
     {
       "name": "yanked-deps (local)",
@@ -178,7 +178,7 @@
           "res": "broken:yanked"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/yanked-deps"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/yanked-deps"
     }
   ]
 }

--- a/tests/minicrater/ignore-blacklist/results.expected.json
+++ b/tests/minicrater/ignore-blacklist/results.expected.json
@@ -13,7 +13,7 @@
           "res": "build-fail:unknown"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-fail"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
     },
     {
       "name": "build-pass (local)",
@@ -28,7 +28,7 @@
           "res": "test-pass"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-pass"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     },
     {
       "name": "test-fail (local)",
@@ -43,7 +43,7 @@
           "res": "test-fail:unknown"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/test-fail"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
     }
   ]
 }

--- a/tests/minicrater/small/results.expected.json
+++ b/tests/minicrater/small/results.expected.json
@@ -13,7 +13,7 @@
           "res": "build-fail:unknown"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/beta-regression"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
     },
     {
       "name": "build-pass (local)",
@@ -28,7 +28,7 @@
           "res": "test-pass"
         }
       ],
-      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-pass"
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     }
   ]
 }


### PR DESCRIPTION
This PR removes all references to `rust-lang-nursery` in the code, as the repo was migrated to the main org.