### PR TITLE
sort crates before report generation

### DIFF
--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -137,6 +137,9 @@ pub fn generate_report<DB: ReadResults>(
     crates: &[Crate],
 ) -> Fallible<TestResults> {
     let shas = db.load_all_shas(ex)?;
+    let mut crates = crates.to_vec();
+    //crate ids are unique so unstable sort is equivalent to stable sort but is generally faster
+    crates.sort_unstable_by(|a, b| a.id().cmp(&b.id()));
     let res = crates
         .iter()
         .map(|krate| {

--- a/tests/minicrater/blacklist/results.expected.json
+++ b/tests/minicrater/blacklist/results.expected.json
@@ -1,6 +1,15 @@
 {
   "crates": [
     {
+      "name": "build-fail (local)",
+      "res": "skipped",
+      "runs": [
+        null,
+        null
+      ],
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
+    },
+    {
       "name": "build-pass (local)",
       "res": "test-pass",
       "runs": [
@@ -29,15 +38,6 @@
         }
       ],
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
-    },
-    {
-      "name": "build-fail (local)",
-      "res": "skipped",
-      "runs": [
-        null,
-        null
-      ],
-      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
     }
   ]
 }

--- a/tests/minicrater/full/results.expected.json
+++ b/tests/minicrater/full/results.expected.json
@@ -91,6 +91,15 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
     },
     {
+      "name": "memory-hungry (local)",
+      "res": "skipped",
+      "runs": [
+        null,
+        null
+      ],
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
+    },
+    {
       "name": "missing-examples (local)",
       "res": "test-pass",
       "runs": [
@@ -164,15 +173,6 @@
         }
       ],
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/yanked-deps"
-    },
-    {
-      "name": "memory-hungry (local)",
-      "res": "skipped",
-      "runs": [
-        null,
-        null
-      ],
-      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
     }
   ]
 }


### PR DESCRIPTION
Until now, the order of the crates in the report file was not specified, and this resulted in unwanted differences in the output of minicrater test runs (i.e. same results but shuffled). This pr sorts the crates before the generation of the report in order to avoid such problems.