### PR TITLE
Normalize WORK_DIR in DiskSpaceWatcher::current_mount so it works on Windows

### DIFF
--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -549,6 +549,8 @@ mod tests {
         use crate::prelude::*;
         use crate::results::{DatabaseDB, EncodingType, FailureReason, TestResult, WriteResults};
 
+        rustwide::logging::init();
+
         let db = Database::temp().unwrap();
         let config = Config::default();
         let ctx = ActionsCtx::new(&db, &config);

--- a/src/runner/worker.rs
+++ b/src/runner/worker.rs
@@ -213,7 +213,7 @@ impl<'a, DB: WriteResults + Sync> DiskSpaceWatcher<'a, DB> {
     }
 
     fn current_mount(&self) -> Fallible<Filesystem> {
-        let current_dir = crate::dirs::WORK_DIR.canonicalize()?;
+        let current_dir = crate::utils::path::normalize_path(&crate::dirs::WORK_DIR);
         let system = System::new();
 
         let mut found = None;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod hex;
 pub(crate) mod http;
 #[macro_use]
 mod macros;
+pub(crate) mod path;
 pub mod size;
 pub(crate) mod string;
 

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -61,6 +61,7 @@ mod windows_tests {
 
     #[test]
     fn strip_verbatim() {
+        rustwide::logging::init();
         let suite = vec![
             (r"C:\Users\carl", None),
             (r"\Users\carl", None),

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -1,0 +1,55 @@
+use log::warn;
+use std::path::{Component, Path, PathBuf, Prefix, PrefixComponent};
+
+pub(crate) fn normalize_path(path: &Path) -> PathBuf {
+    let mut p = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+    // `fs::canonicalize` returns an extended-length path on Windows. Such paths not supported by
+    // many programs, including rustup. We strip the `\\?\` prefix of the canonicalized path, but
+    // this changes the meaning of some path components, and imposes a length of around 260
+    // characters.
+    if cfg!(windows) {
+        // A conservative estimate for the maximum length of a path on Windows.
+        //
+        // The additional 12 byte restriction is applied when creating directories. It ensures that
+        // files can always be created inside that directory without exceeding the path limit.
+        const MAX_PATH_LEN: usize = 260 - 12;
+
+        let mut components = p.components();
+        let first_component = components.next().unwrap();
+
+        if let Component::Prefix(prefix) = first_component {
+            if let Some(mut modified_path) = strip_verbatim_from_prefix(&prefix) {
+                modified_path.push(components.as_path());
+                p = modified_path;
+            }
+        }
+
+        if p.as_os_str().len() >= MAX_PATH_LEN {
+            warn!(
+                "Canonicalized path is too long for Windows: {:?}",
+                p.as_os_str(),
+            );
+        }
+    }
+
+    p
+}
+
+/// If a prefix uses the extended-length syntax (`\\?\`), return the equivalent version without it.
+///
+/// Returns `None` if `prefix.kind().is_verbatim()` is `false`.
+fn strip_verbatim_from_prefix(prefix: &PrefixComponent<'_>) -> Option<PathBuf> {
+    let ret = match prefix.kind() {
+        Prefix::Verbatim(s) => Path::new(s).to_owned(),
+
+        Prefix::VerbatimDisk(drive) => [format!(r"{}:\", drive as char)].iter().collect(),
+
+        Prefix::VerbatimUNC(_, _) => unimplemented!(),
+
+        _ => return None,
+    };
+
+    Some(ret)
+}
+

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -53,3 +53,31 @@ fn strip_verbatim_from_prefix(prefix: &PrefixComponent<'_>) -> Option<PathBuf> {
     Some(ret)
 }
 
+#[cfg(test)]
+#[cfg(windows)]
+mod windows_tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn strip_verbatim() {
+        let suite = vec![
+            (r"C:\Users\carl", None),
+            (r"\Users\carl", None),
+            (r"\\?\C:\Users\carl", Some(r"C:\")),
+            (r"\\?\Users\carl", Some(r"Users")),
+        ];
+
+        for (input, output) in suite {
+            let p = Path::new(input);
+            let first_component = p.components().next().unwrap();
+
+            if let Component::Prefix(prefix) = &first_component {
+                let stripped = strip_verbatim_from_prefix(&prefix);
+                assert_eq!(stripped.as_ref().map(|p| p.to_str().unwrap()), output);
+            } else {
+                assert!(output.is_none());
+            }
+        }
+    }
+}

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -61,7 +61,6 @@ mod windows_tests {
 
     #[test]
     fn strip_verbatim() {
-        rustwide::logging::init();
         let suite = vec![
             (r"C:\Users\carl", None),
             (r"\Users\carl", None),


### PR DESCRIPTION
Currently the call to `canonicalize` includes the strange extended path prefix on Windows. Fixing it requires doing what is currently done in [rustwide](https://github.com/rust-lang/rustwide/blob/master/src/utils.rs#L53). I've simply copy/pasted the code since both making it public in rustwide and making an independent crate seem like the wrong things to do. 

For more information on normalizing extended path's on Windows, you can read [this SO article](https://stackoverflow.com/questions/50322817/how-do-i-remove-the-prefix-from-a-canonical-windows-path).