### PR TITLE
Use resilient `remove_dir_all` for Windows compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ rust_team_data = { git = "https://github.com/rust-lang/team" }
 systemstat = "0.1.4"
 rustwide = "0.1.0"
 percent-encoding = "2.1.0"
+remove_dir_all = "0.5.2"
 
 [dev-dependencies]
 assert_cmd = "0.10.1"

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -3,6 +3,7 @@ use crate::results::{BrokenReason, EncodingType, FailureReason, TestResult, Writ
 use crate::runner::tasks::TaskCtx;
 use crate::runner::OverrideResult;
 use failure::Error;
+use remove_dir_all::remove_dir_all;
 use rustwide::cmd::{CommandError, SandboxBuilder};
 use rustwide::{Build, PrepareError};
 
@@ -208,7 +209,7 @@ pub(super) fn test_rustdoc<DB: WriteResults>(
 
     // Make sure to remove the built documentation
     // There is no point in storing it after the build is done
-    std::fs::remove_dir_all(&build_env.host_target_dir().join("doc"))?;
+    remove_dir_all(&build_env.host_target_dir().join("doc"))?;
 
     if let Err(err) = res {
         Ok(TestResult::BuildFail(failure_reason(&err)))


### PR DESCRIPTION
`std::fs::remove_dir_all` can fail spuriously on Windows, causing tests to be marked as failed.