### PR TITLE
Add experiment requirements

### DIFF
--- a/docs/agent-http-api.md
+++ b/docs/agent-http-api.md
@@ -64,11 +64,28 @@ behave this way:
 All the endpoints return a JSON response with a 200 status code if the request
 succeded.
 
-### `GET /config`
+### `POST /config`
 
-This endpoint returns the generic configuration of this agent, assigned by the
-crater server. This method should be called at least at the start of the agent,
-and the response is tied to the API token.
+This endpoint registers the capabilities of this agent, and returns the generic
+configuration of this agent, assigned by the crater server. This method should
+be called at least at the start of the agent, and the response is tied to the
+API token.
+
+The agent's capabilities must be specified as JSON in the request body. Prior
+to the introduction of capabilities, this endpoint was accessed via a `GET`
+instead of a `POST`. A `GET` to this endpoint will still register an agent, but
+the request body will be ignored and a default set of capabilities used instead
+(currently `["linux"]`).
+
+Request fields:
+
+* `capabilities`: an array containing the capabilities possessed by this agent.
+
+```json
+{
+    "capabilities": ["windows", "hard-drive-bigger-than-1TB"]
+}
+```
 
 Response fields:
 
@@ -88,10 +105,10 @@ Response fields:
 ### `GET /next-experiment`
 
 This endpoint returns the next experiment this agent should run. The first time
-this method is called the first queued experiment is assigned to the agent, and
-its configuration is returned. The same configuration is returned for all the
-following calls, until the agent sends the full experiment result to the crater
-server.
+this method is called the first queued experiment with compatible requirements
+is assigned to the agent, and its configuration is returned. The same
+configuration is returned for all the following calls, until the agent sends
+the full experiment result to the crater server.
 
 Response fields:
 

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -102,6 +102,15 @@ commands. At the moment, the name is predicted in these cases:
 
 [Go back to the TOC][h-toc]
 
+## Experiment requirements
+
+Crater uses a system of requirements and capabilities to control which class of
+agent can run which experiments. For now, there are two classes of agents:
+Linux agents have the capability `linux`, and Windows agents have the
+capability `windows`. You must specify a requirement for your experiment
+(either `linux` or `windows`), and your experiment will only run on agents with
+that capability.
+
 ## Commands reference
 
 ### Creating experiments
@@ -125,6 +134,7 @@ beta run you can use:
 * `crates`: the selection of crates to use (default: `full`)
 * `cap-lints`: the lints cap (default: `forbid`, which means no cap)
 * `ignore-blacklist`: whether the blacklist should be ignored (default: `false`)
+* `requirement`: any requirement of the agent running the experiment (default: `linux`)
 * `assign`: assign the experiment to a specific agent (use this only when you
   know what you're doing)
 * `p`: the priority of the run (default: `0`)
@@ -153,6 +163,7 @@ priority of the `foo` experiment you can use:
 * `crates`: the selection of crates to use (default: `full`)
 * `cap-lints`: the lints cap (default: `forbid`, which means no cap)
 * `ignore-blacklist`: whether the blacklist should be ignored (default: `false`)
+* `requirement`: any requirement of the agent running the experiment (default: `linux`)
 * `assign`: assign the experiment to a specific agent (use this only when you
   know what you're doing)
 * `p`: the priority of the run (default: `0`)

--- a/src/actions/experiments/create.rs
+++ b/src/actions/experiments/create.rs
@@ -15,6 +15,7 @@ pub struct CreateExperiment {
     pub github_issue: Option<GitHubIssue>,
     pub ignore_blacklist: bool,
     pub assign: Option<Assignee>,
+    pub requirement: Option<String>,
 }
 
 impl CreateExperiment {
@@ -32,6 +33,7 @@ impl CreateExperiment {
             github_issue: None,
             ignore_blacklist: false,
             assign: None,
+            requirement: None,
         }
     }
 }
@@ -55,8 +57,8 @@ impl Action for CreateExperiment {
                 "INSERT INTO experiments \
                  (name, mode, cap_lints, toolchain_start, toolchain_end, priority, created_at, \
                  status, github_issue, github_issue_url, github_issue_number, ignore_blacklist, \
-                 assigned_to) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13);",
+                 assigned_to, requirement) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14);",
                 &[
                     &self.name,
                     &self.mode.to_str(),
@@ -71,6 +73,7 @@ impl Action for CreateExperiment {
                     &self.github_issue.as_ref().map(|i| i.number),
                     &self.ignore_blacklist,
                     &self.assign.map(|a| a.to_string()),
+                    &self.requirement,
                 ],
             )?;
 
@@ -126,6 +129,7 @@ mod tests {
             }),
             ignore_blacklist: true,
             assign: None,
+            requirement: Some("linux".to_string()),
         }
         .apply(&ctx)
         .unwrap();
@@ -152,6 +156,7 @@ mod tests {
         assert_eq!(ex.status, Status::Queued);
         assert!(ex.assigned_to.is_none());
         assert!(ex.ignore_blacklist);
+        assert_eq!(ex.requirement, Some("linux".to_string()));
     }
 
     #[test]
@@ -250,6 +255,7 @@ mod tests {
             github_issue: None,
             ignore_blacklist: false,
             assign: None,
+            requirement: None,
         }
         .apply(&ctx)
         .unwrap_err();
@@ -279,6 +285,7 @@ mod tests {
             github_issue: None,
             ignore_blacklist: false,
             assign: None,
+            requirement: None,
         }
         .apply(&ctx)
         .unwrap();
@@ -294,6 +301,7 @@ mod tests {
             github_issue: None,
             ignore_blacklist: false,
             assign: None,
+            requirement: None,
         }
         .apply(&ctx)
         .unwrap_err();

--- a/src/actions/experiments/edit.rs
+++ b/src/actions/experiments/edit.rs
@@ -13,6 +13,7 @@ pub struct EditExperiment {
     pub priority: Option<i32>,
     pub ignore_blacklist: Option<bool>,
     pub assign: Option<Assignee>,
+    pub requirement: Option<String>,
 }
 
 impl EditExperiment {
@@ -27,6 +28,7 @@ impl EditExperiment {
             priority: None,
             ignore_blacklist: None,
             assign: None,
+            requirement: None,
         }
     }
 }
@@ -146,6 +148,16 @@ impl Action for EditExperiment {
                 ex.assigned_to = Some(assign);
             }
 
+            // Try to update the requirement
+            if let Some(requirement) = self.requirement {
+                let changes = t.execute(
+                    "UPDATE experiments SET requirement = ?1 WHERE name = ?2;",
+                    &[&requirement.to_string(), &self.name],
+                )?;
+                assert_eq!(changes, 1);
+                ex.requirement = Some(requirement);
+            }
+
             Ok(())
         })?;
         Ok(())
@@ -193,6 +205,7 @@ mod tests {
             github_issue: None,
             ignore_blacklist: false,
             assign: None,
+            requirement: None,
         }
         .apply(&ctx)
         .unwrap();
@@ -210,6 +223,7 @@ mod tests {
             priority: Some(10),
             ignore_blacklist: Some(true),
             assign: Some(Assignee::CLI),
+            requirement: Some("windows".to_string()),
         }
         .apply(&ctx)
         .unwrap();
@@ -224,6 +238,7 @@ mod tests {
         assert_eq!(ex.priority, 10);
         assert_eq!(ex.ignore_blacklist, true);
         assert_eq!(ex.assigned_to, Some(Assignee::CLI));
+        assert_eq!(ex.requirement, Some("windows".to_string()));
 
         assert_eq!(
             ex.get_crates(&ctx.db).unwrap(),

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -1,3 +1,4 @@
+use crate::agent::Capabilities;
 use crate::crates::{Crate, GitHubRepo};
 use crate::experiments::Experiment;
 use crate::prelude::*;
@@ -120,9 +121,10 @@ impl AgentApi {
         }
     }
 
-    pub fn config(&self) -> Fallible<AgentConfig> {
+    pub fn config(&self, caps: &Capabilities) -> Fallible<AgentConfig> {
         self.retry(|this| {
-            this.build_request(Method::GET, "config")
+            this.build_request(Method::POST, "config")
+                .json(&json!(caps))
                 .send()?
                 .to_api_response()
         })

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -584,10 +584,11 @@ impl Crater {
                 ref capabilities,
                 no_default_capabilities,
             } => {
-                let mut caps = Capabilities::default();
-                if !no_default_capabilities {
-                    caps.extend(default_capabilities_for_target().drain(..));
-                }
+                let mut caps = if no_default_capabilities {
+                    Capabilities::default()
+                } else {
+                    default_capabilities_for_target()
+                };
                 caps.extend(capabilities.clone().into_iter());
 
                 agent::run(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,6 +172,8 @@ pub enum Crater {
         no_ignore_blacklist: bool,
         #[structopt(name = "assign", long = "assign")]
         assign: Option<Assignee>,
+        #[structopt(name = "requirement", long = "requirement")]
+        requirement: Option<String>,
     },
 
     #[structopt(name = "delete-ex", about = "delete shared data for experiment")]
@@ -350,6 +352,7 @@ impl Crater {
                 ref ignore_blacklist,
                 ref no_ignore_blacklist,
                 ref assign,
+                ref requirement,
             } => {
                 let config = Config::load()?;
                 let db = Database::open()?;
@@ -372,6 +375,7 @@ impl Crater {
                     priority: *priority,
                     ignore_blacklist,
                     assign: assign.clone(),
+                    requirement: requirement.clone(),
                 }
                 .apply(&ctx)?;
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -271,14 +271,17 @@ pub enum Crater {
         fast_workspace_init: bool,
         #[structopt(
             name = "capabilities",
-            help = "Registers additional capabilities for this agent. \
-                    These will be appended to the defaults for this platform, unless they have \
-                    been disabled via `--no-default-capabilities`",
+            help = "Registers additional capabilities for this agent.",
+            long_help = "Registers additional capabilities for this agent.\n\n \
+                         These will be appended to the defaults for this platform, unless those \
+                         have been disabled via `--no-default-capabilities`.",
+            long,
             raw(use_delimiter = "true")
         )]
         capabilities: Vec<String>,
         #[structopt(
             name = "no-default-capabilities",
+            long,
             help = "Disables the default capabilities for this platform."
         )]
         no_default_capabilities: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,6 +126,8 @@ pub enum Crater {
         ignore_blacklist: bool,
         #[structopt(name = "assign", long = "assign")]
         assign: Option<Assignee>,
+        #[structopt(name = "requirement", long = "requirement")]
+        requirement: Option<String>,
     },
 
     #[structopt(name = "edit", about = "edit an experiment configuration")]
@@ -317,6 +319,7 @@ impl Crater {
                 ref priority,
                 ref ignore_blacklist,
                 ref assign,
+                ref requirement,
             } => {
                 let config = Config::load()?;
                 let db = Database::open()?;
@@ -332,6 +335,7 @@ impl Crater {
                     github_issue: None,
                     ignore_blacklist: *ignore_blacklist,
                     assign: assign.clone(),
+                    requirement: requirement.clone(),
                 }
                 .apply(&ctx)?;
             }

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -287,6 +287,23 @@ fn migrations() -> Vec<(&'static str, MigrationKind)> {
         ),
     ));
 
+    migrations.push((
+        "add_agent_capabilities",
+        MigrationKind::SQL(
+            "
+            CREATE TABLE agent_capabilities (
+                agent_name TEXT NOT NULL,
+                capability TEXT NOT NULL,
+
+                PRIMARY KEY (agent_name, capability) ON CONFLICT REPLACE,
+                FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
+            );
+
+            CREATE INDEX agent__name ON agent_capabilities(agent_name);
+            ",
+        ),
+    ));
+
     migrations
 }
 

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -278,6 +278,15 @@ fn migrations() -> Vec<(&'static str, MigrationKind)> {
         ),
     ));
 
+    migrations.push((
+        "add_experiment_field_requirement",
+        MigrationKind::SQL(
+            "
+            ALTER TABLE experiments ADD COLUMN requirement TEXT DEFAULT 'linux';
+            ",
+        ),
+    ));
+
     migrations
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -140,6 +140,16 @@ pub trait QueryUtils {
         })
     }
 
+    fn execute_cached(&self, sql: &str, params: &[&dyn ToSql]) -> Fallible<usize> {
+        self.with_conn(|conn| {
+            self.trace(sql, || {
+                let mut prepared = conn.prepare_cached(sql)?;
+                let changes = prepared.execute(params)?;
+                Ok(changes)
+            })
+        })
+    }
+
     fn get_row<T, P>(
         &self,
         sql: &str,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -140,12 +140,16 @@ pub trait QueryUtils {
         })
     }
 
-    fn get_row<T, F: FnMut(&Row) -> T>(
+    fn get_row<T, P>(
         &self,
         sql: &str,
-        params: &[&dyn ToSql],
-        func: F,
-    ) -> Fallible<Option<T>> {
+        params: P,
+        func: impl FnMut(&Row) -> T,
+    ) -> Fallible<Option<T>>
+    where
+        P: IntoIterator,
+        P::Item: ToSql,
+    {
         self.with_conn(|conn| {
             self.trace(sql, || {
                 let mut prepared = conn.prepare(sql)?;

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -146,7 +146,7 @@ impl Experiment {
         let record = db.get_row(
             "SELECT * FROM experiments \
              WHERE status = ?1 AND assigned_to = ?2;",
-            &[&Status::Running.to_str(), &assignee.to_string()],
+            &[Status::Running.to_str(), &assignee.to_string()],
             |r| ExperimentDBRecord::from_row(r),
         )?;
 

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -123,6 +123,7 @@ pub struct Experiment {
     pub assigned_to: Option<Assignee>,
     pub report_url: Option<String>,
     pub ignore_blacklist: bool,
+    pub requirement: Option<String>,
 }
 
 impl Experiment {
@@ -354,6 +355,7 @@ struct ExperimentDBRecord {
     assigned_to: Option<String>,
     report_url: Option<String>,
     ignore_blacklist: bool,
+    requirement: Option<String>,
 }
 
 impl ExperimentDBRecord {
@@ -375,6 +377,7 @@ impl ExperimentDBRecord {
             assigned_to: row.get("assigned_to"),
             report_url: row.get("report_url"),
             ignore_blacklist: row.get("ignore_blacklist"),
+            requirement: row.get("requirement"),
         }
     }
 
@@ -409,6 +412,7 @@ impl ExperimentDBRecord {
             status: self.status.parse()?,
             report_url: self.report_url,
             ignore_blacklist: self.ignore_blacklist,
+            requirement: self.requirement,
         })
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -695,6 +695,7 @@ mod tests {
             assigned_to: None,
             report_url: None,
             ignore_blacklist: false,
+            requirement: None,
         };
 
         let mut db = DummyDB::default();

--- a/src/server/agents.rs
+++ b/src/server/agents.rs
@@ -1,3 +1,4 @@
+use crate::agent::Capabilities;
 use crate::db::{Database, QueryUtils};
 use crate::experiments::{Assignee, Experiment};
 use crate::prelude::*;
@@ -145,6 +146,18 @@ impl Agents {
         assert_eq!(changes, 1);
 
         Ok(())
+    }
+
+    pub fn add_capabilities(&self, agent: &str, caps: &Capabilities) -> Fallible<()> {
+        const SQL: &str = "INSERT INTO agent_capabilities (agent_name, capability) VALUES (?, ?)";
+
+        self.db.transaction(|t| {
+            for cap in caps.iter() {
+                t.execute_cached(SQL, &[&agent, &cap])?;
+            }
+
+            Ok(())
+        })
     }
 }
 

--- a/src/server/agents.rs
+++ b/src/server/agents.rs
@@ -65,6 +65,10 @@ impl Agent {
 
         AgentStatus::Unreachable
     }
+
+    pub fn capabilities(&self) -> Option<&Capabilities> {
+        self.capabilities.as_ref()
+    }
 }
 
 #[derive(Clone)]
@@ -113,8 +117,11 @@ impl Agents {
                 }
             })?
             .into_iter()
-            .map(|agent| agent.with_experiment(&self.db)
-                .and_then(|agent| agent.with_capabilities(&self.db)))
+            .map(|agent| {
+                agent
+                    .with_experiment(&self.db)
+                    .and_then(|agent| agent.with_capabilities(&self.db))
+            })
             .collect()
     }
 

--- a/src/server/agents.rs
+++ b/src/server/agents.rs
@@ -22,11 +22,17 @@ pub struct Agent {
     experiment: Option<Experiment>,
     last_heartbeat: Option<DateTime<Utc>>,
     git_revision: Option<String>,
+    capabilities: Option<Capabilities>,
 }
 
 impl Agent {
     fn with_experiment(mut self, db: &Database) -> Fallible<Self> {
         self.experiment = Experiment::run_by(db, &Assignee::Agent(self.name.clone()))?;
+        Ok(self)
+    }
+
+    fn with_capabilities(mut self, db: &Database) -> Fallible<Self> {
+        self.capabilities = Some(Capabilities::for_agent(db, &self.name)?);
         Ok(self)
     }
 
@@ -100,32 +106,37 @@ impl Agents {
                     name: row.get("name"),
                     last_heartbeat: row.get("last_heartbeat"),
                     git_revision: row.get("git_revision"),
-                    experiment: None, // Lazy loaded after this
+
+                    // Lazy loaded after this
+                    experiment: None,
+                    capabilities: None,
                 }
             })?
             .into_iter()
-            .map(|agent| agent.with_experiment(&self.db))
+            .map(|agent| agent.with_experiment(&self.db)
+                .and_then(|agent| agent.with_capabilities(&self.db)))
             .collect()
     }
 
     #[cfg(test)]
     fn get(&self, name: &str) -> Fallible<Option<Agent>> {
-        let row = self
-            .db
+        self.db
             .get_row("SELECT * FROM agents WHERE name = ?1;", &[&name], |row| {
                 Agent {
                     name: row.get("name"),
                     last_heartbeat: row.get("last_heartbeat"),
                     git_revision: row.get("git_revision"),
-                    experiment: None, // Lazy loaded after this
-                }
-            })?;
 
-        Ok(if let Some(agent) = row {
-            Some(agent.with_experiment(&self.db)?)
-        } else {
-            None
-        })
+                    // Lazy loaded after this
+                    experiment: None,
+                    capabilities: None,
+                }
+            })?
+            .map(|agent| agent.with_experiment(&self.db))
+            .transpose()?
+            .map(|agent| agent.with_capabilities(&self.db))
+            .transpose()
+            .map_err(Into::into)
     }
 
     pub fn record_heartbeat(&self, agent: &str) -> Fallible<()> {
@@ -165,6 +176,7 @@ impl Agents {
 mod tests {
     use super::{AgentStatus, Agents};
     use crate::actions::{Action, ActionsCtx, CreateExperiment};
+    use crate::agent::Capabilities;
     use crate::config::Config;
     use crate::db::Database;
     use crate::experiments::{Assignee, Experiment};
@@ -254,5 +266,22 @@ mod tests {
         // After an experiment is assigned to the agent, the agent is working
         let agent = agents.get("agent").unwrap().unwrap();
         assert_eq!(agent.status(), AgentStatus::Working);
+    }
+
+    #[test]
+    fn test_agent_capabilities() {
+        let db = Database::temp().unwrap();
+
+        let mut tokens = Tokens::default();
+        tokens.agents.insert("token".into(), "agent".into());
+        let agents = Agents::new(db.clone(), &tokens).unwrap();
+
+        // Insert capabilities into database
+        let caps = Capabilities::new(&["linux", "big-hard-drive"]);
+        agents.add_capabilities("agent", &caps).unwrap();
+
+        // Ensure that capabilities are preserved across a round trip to the database.
+        let caps_from_db = Capabilities::for_agent(&db, "agent").unwrap();
+        assert!(caps.iter().eq(caps_from_db.iter()));
     }
 }

--- a/src/server/routes/ui/agents.rs
+++ b/src/server/routes/ui/agents.rs
@@ -15,6 +15,7 @@ struct AgentData {
     last_heartbeat: Option<String>,
     assigned_experiment: Option<String>,
     git_revision: Option<String>,
+    capabilities: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -32,6 +33,13 @@ pub fn endpoint_list(data: Arc<Data>) -> Fallible<Response<Body>> {
             AgentStatus::Unreachable => ("red", "Unreachable", false),
         };
 
+        let capabilities = agent
+            .capabilities()
+            .expect("Capabilities were loaded from the db")
+            .iter()
+            .cloned()
+            .collect();
+
         agents.push(AgentData {
             name: agent.name().to_string(),
             status_class,
@@ -45,6 +53,7 @@ pub fn endpoint_list(data: Arc<Data>) -> Fallible<Response<Body>> {
                 None
             },
             git_revision: agent.git_revision().cloned(),
+            capabilities,
         });
     }
 

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -141,6 +141,7 @@ generate_parser!(pub enum Command {
         priority: Option<i32> = "p",
         ignore_blacklist: Option<bool> = "ignore-blacklist",
         assign: Option<Assignee> = "assign",
+        requirement: Option<String> = "requirement",
     })
 });
 

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -112,6 +112,7 @@ generate_parser!(pub enum Command {
         priority: Option<i32> = "p",
         ignore_blacklist: Option<bool> = "ignore-blacklist",
         assign: Option<Assignee> = "assign",
+        requirement: Option<String> = "requirement",
     })
 
     "abort" => Abort(AbortArgs {

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -113,6 +113,7 @@ pub fn edit(data: &Data, issue: &Issue, args: EditArgs) -> Fallible<()> {
         priority: args.priority,
         ignore_blacklist: args.ignore_blacklist,
         assign: args.assign,
+        requirement: args.requirement,
     }
     .apply(&ActionsCtx::new(&data.db, &data.config))?;
 

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -54,6 +54,9 @@ pub fn run(
         }
     }
 
+    // Make crater runs created via webhook require linux by default.
+    let requirement = args.requirement.unwrap_or_else(|| "linux".to_string());
+
     actions::CreateExperiment {
         name: name.clone(),
         toolchains: [
@@ -75,6 +78,7 @@ pub fn run(
         }),
         ignore_blacklist: args.ignore_blacklist.unwrap_or(false),
         assign: args.assign,
+        requirement: Some(requirement),
     }
     .apply(&ActionsCtx::new(&data.db, &data.config))?;
 

--- a/src/server/try_builds.rs
+++ b/src/server/try_builds.rs
@@ -51,7 +51,7 @@ pub(crate) fn detect(
 pub(crate) fn get_sha(db: &Database, repo: &str, pr: i32) -> Fallible<Option<TryBuild>> {
     db.get_row(
         "SELECT base_sha, merge_sha FROM try_builds WHERE repo = ?1 AND pr = ?2;",
-        &[&repo, &pr],
+        &[repo, &pr.to_string()],
         |row| TryBuild {
             base_sha: row.get("base_sha"),
             merge_sha: row.get("merge_sha"),

--- a/templates/ui/agents.html
+++ b/templates/ui/agents.html
@@ -10,6 +10,7 @@
                 <table class="list">
                     <tr>
                         <th>Name</th>
+                        <th>Capabilities</th>
                         <th>Status</th>
                         <th>Last heartbeat</th>
                         <th>Assigned experiment</th>
@@ -18,6 +19,7 @@
                     {% for agent in agents %}
                         <tr>
                             <td>{{ agent.name }}</td>
+                            <td>{{ agent.capabilities | join(sep=", ") }}</td>
                             <td class="{{ agent.status_class }}">{{ agent.status_pretty }}</td>
                             <td>
                                 {% if agent.last_heartbeat %}

--- a/templates/ui/agents.html
+++ b/templates/ui/agents.html
@@ -19,7 +19,13 @@
                     {% for agent in agents %}
                         <tr>
                             <td>{{ agent.name }}</td>
-                            <td>{{ agent.capabilities | join(sep=", ") }}</td>
+                            <td>
+                                {% if agent.capabilities %}
+                                    {{ agent.capabilities | join(sep=", ") }}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
                             <td class="{{ agent.status_class }}">{{ agent.status_pretty }}</td>
                             <td>
                                 {% if agent.last_heartbeat %}


### PR DESCRIPTION
Resolves #430.

This adds a `requirement` field to `Experiment`, which specifies what requirements (if any) an agent must meet to run that experiment.  Requirements are not structured, they are simply strings which are compared for equality. Agents advertise what requirements they meet via the request body when getting their configuration from the `/config` endpoint. Only experiments whose requirements are a subset of an agent's capabilities can be assigned to that agent. By default, experiments created via the CLI have no requirements--they can be run on any machine--and ones created via webhook (e.g. from `craterbot`) have the `linux`requirement--they must be run on a Linux machine. 
    
For now, an experiment can have zero or one requirements. In the future, we may want to allow experiments to have an arbitrary number of requirements, and only agents which match all of them will be selected to run that experiment. This would require an additional table however.

For a crater run to be scheduled on both a Linux and Windows agent, you'll need to invoke `craterbot` twice, once with the `linux` requirement and once with the `windows` requirement. Perhaps later we could add some sugar for this?

r? @pietroalbini 

