### PR TITLE
report private repository error as broken crate

### DIFF
--- a/src/crates/lists.rs
+++ b/src/crates/lists.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::crates::sources::github::GitHubRepo;
 use crate::crates::{Crate, RegistryCrate};
 use crate::db::{Database, QueryUtils};
 use crate::experiments::CrateSelect;
@@ -129,6 +130,7 @@ pub(crate) fn get_crates(
         CrateSelect::Local => {
             crates.append(&mut LocalList::get(db)?);
         }
+        CrateSelect::Dummy => crates.push(Crate::GitHub(GitHubRepo::dummy())),
     }
 
     crates.sort();

--- a/src/crates/sources/github.rs
+++ b/src/crates/sources/github.rs
@@ -5,6 +5,8 @@ use std::str::FromStr;
 
 static CACHED_LIST: &str =
     "https://raw.githubusercontent.com/rust-ops/rust-repos/master/data/github.csv";
+const DUMMY_ORG: &str = "ghost";
+const DUMMY_NAME: &str = "missing";
 
 #[derive(Deserialize)]
 struct ListRepo {
@@ -72,6 +74,13 @@ pub struct GitHubRepo {
 impl GitHubRepo {
     pub(crate) fn slug(&self) -> String {
         format!("{}/{}", self.org, self.name)
+    }
+
+    pub(crate) fn dummy() -> GitHubRepo {
+        GitHubRepo {
+            org: DUMMY_ORG.to_string(),
+            name: DUMMY_NAME.to_string(),
+        }
     }
 }
 

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -33,6 +33,7 @@ string_enum!(pub enum CrateSelect {
     SmallRandom => "small-random",
     Top100 => "top-100",
     Local => "local",
+    Dummy => "dummy",
 });
 
 string_enum!(pub enum CapLints {

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -68,6 +68,7 @@ impl ResultName for BrokenReason {
             BrokenReason::Unknown => "broken crate".into(),
             BrokenReason::CargoToml => "broken Cargo.toml".into(),
             BrokenReason::Yanked => "deps yanked".into(),
+            BrokenReason::PrivateGitRepository => "private repo".into(),
         }
     }
 }

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -68,7 +68,7 @@ impl ResultName for BrokenReason {
             BrokenReason::Unknown => "broken crate".into(),
             BrokenReason::CargoToml => "broken Cargo.toml".into(),
             BrokenReason::Yanked => "deps yanked".into(),
-            BrokenReason::PrivateGitRepository => "private repo".into(),
+            BrokenReason::MissingGitRepository => "missing repo".into(),
         }
     }
 }

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -185,7 +185,7 @@ string_enum!(pub enum BrokenReason {
     Unknown => "unknown",
     CargoToml => "cargo-toml",
     Yanked => "yanked",
-    PrivateGitRepository => "private-git-repository",
+    MissingGitRepository => "missing-git-repository",
 });
 
 test_result_enum!(pub enum TestResult {

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -185,6 +185,7 @@ string_enum!(pub enum BrokenReason {
     Unknown => "unknown",
     CargoToml => "cargo-toml",
     Yanked => "yanked",
+    PrivateGitRepository => "private-git-repository",
 });
 
 test_result_enum!(pub enum TestResult {

--- a/src/runner/tasks.rs
+++ b/src/runner/tasks.rs
@@ -3,6 +3,7 @@ use crate::crates::Crate;
 use crate::experiments::Experiment;
 use crate::prelude::*;
 use crate::results::{EncodingType, TestResult, WriteResults};
+use crate::runner::test::detect_broken;
 use crate::runner::{test, RunnerState};
 use crate::toolchain::Toolchain;
 use crate::utils;
@@ -178,7 +179,7 @@ impl Task {
                     .insert(self.krate.clone(), storage.clone());
                 logging::capture(&storage, || {
                     let rustwide_crate = self.krate.to_rustwide();
-                    rustwide_crate.fetch(workspace)?;
+                    detect_broken(rustwide_crate.fetch(workspace))?;
 
                     if let Crate::GitHub(repo) = &self.krate {
                         if let Some(sha) = rustwide_crate.git_commit(workspace) {

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -21,7 +21,7 @@ fn failure_reason(err: &Error) -> FailureReason {
     FailureReason::Unknown
 }
 
-fn detect_broken<T>(res: Result<T, Error>) -> Result<T, Error> {
+pub(super) fn detect_broken<T>(res: Result<T, Error>) -> Result<T, Error> {
     match res {
         Ok(ok) => Ok(ok),
         Err(err) => {
@@ -33,7 +33,7 @@ fn detect_broken<T>(res: Result<T, Error>) -> Result<T, Error> {
                         PrepareError::InvalidCargoTomlSyntax => Some(BrokenReason::CargoToml),
                         PrepareError::YankedDependencies => Some(BrokenReason::Yanked),
                         PrepareError::PrivateGitRepository => {
-                            Some(BrokenReason::PrivateGitRepository)
+                            Some(BrokenReason::MissingGitRepository)
                         }
                         _ => None,
                     }

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -27,16 +27,20 @@ fn detect_broken<T>(res: Result<T, Error>) -> Result<T, Error> {
         Err(err) => {
             let mut reason = None;
             for cause in err.iter_chain() {
-                if let Some(&PrepareError::MissingCargoToml) = cause.downcast_ctx() {
-                    reason = Some(BrokenReason::CargoToml);
-                } else if let Some(&PrepareError::InvalidCargoTomlSyntax) = cause.downcast_ctx() {
-                    reason = Some(BrokenReason::CargoToml);
-                } else if let Some(&PrepareError::YankedDependencies) = cause.downcast_ctx() {
-                    reason = Some(BrokenReason::Yanked);
-                } else {
-                    continue;
+                if let Some(error) = cause.downcast_ctx() {
+                    reason = match *error {
+                        PrepareError::MissingCargoToml => Some(BrokenReason::CargoToml),
+                        PrepareError::InvalidCargoTomlSyntax => Some(BrokenReason::CargoToml),
+                        PrepareError::YankedDependencies => Some(BrokenReason::Yanked),
+                        PrepareError::PrivateGitRepository => {
+                            Some(BrokenReason::PrivateGitRepository)
+                        }
+                        _ => None,
+                    }
                 }
-                break;
+                if reason.is_some() {
+                    break;
+                }
             }
             if let Some(reason) = reason {
                 Err(err

--- a/tests/minicrater/missing-repo/config.toml
+++ b/tests/minicrater/missing-repo/config.toml
@@ -1,0 +1,24 @@
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
+
+[server.labels]
+remove = "^S-"
+experiment-queued = "S-waiting-on-crater"
+experiment-completed = "S-waiting-on-review"
+
+[demo-crates]
+crates = []
+github-repos = []
+local-crates = []
+
+[sandbox]
+memory-limit = "512M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
+
+[crates]
+
+[github-repos]
+
+[local-crates]

--- a/tests/minicrater/missing-repo/results.expected.json
+++ b/tests/minicrater/missing-repo/results.expected.json
@@ -1,0 +1,19 @@
+{
+  "crates": [
+    {
+      "name": "ghost.missing",
+      "res": "broken",
+      "runs": [
+        {
+          "log": "stable/gh/ghost.missing",
+          "res": "broken:missing-git-repository"
+        },
+        {
+          "log": "beta/gh/ghost.missing",
+          "res": "broken:missing-git-repository"
+        }
+      ],
+      "url": "https://github.com/ghost/missing"
+    }
+  ]
+}

--- a/tests/minicrater/mod.rs
+++ b/tests/minicrater/mod.rs
@@ -42,6 +42,12 @@ minicrater! {
         ..Default::default()
     },
 
+    single_thread_missing_repo {
+        ex: "missing-repo",
+        crate_select: "dummy",
+        ..Default::default()
+    },
+
     #[cfg(not(windows))] // `State.OOMKilled` is not set on Windows
     resource_exhaustion {
         ex: "resource-exhaustion",


### PR DESCRIPTION
Change crate result from `Error` to `Broken` if the crate repo is private or not available.