### PR TITLE
Render experiment requirements in UI

### DIFF
--- a/src/server/routes/ui/experiments.rs
+++ b/src/server/routes/ui/experiments.rs
@@ -15,6 +15,7 @@ struct ExperimentData {
     status_pretty: &'static str,
     mode: &'static str,
     assigned_to: Option<String>,
+    requirement: Option<String>,
     progress: u8,
     priority: i32,
 }
@@ -45,6 +46,7 @@ impl ExperimentData {
             },
             assigned_to: experiment.assigned_to.as_ref().map(|a| a.to_string()),
             priority: experiment.priority,
+            requirement: experiment.requirement.clone(),
             progress: if show_progress {
                 experiment.progress(&data.db)?
             } else {

--- a/templates/ui/experiment.html
+++ b/templates/ui/experiment.html
@@ -37,12 +37,14 @@
                             <th>Mode:</th>
                             <td>{{ experiment.mode }}</td>
                         </tr>
-                        {% if experiment.assigned_to %}
                         <tr>
                             <th>Assigned agent:</th>
                             <td>{{ experiment.assigned_to }}</td>
                         </tr>
-                        {% endif %}
+                        <tr>
+                            <th>Requirements:</th>
+                            <td>{{ experiment.requirement }}</td>
+                        </tr>
                         <tr>
                             <th>Priority:</th>
                             <td>{{ experiment.priority }}</td>

--- a/templates/ui/experiment.html
+++ b/templates/ui/experiment.html
@@ -37,14 +37,18 @@
                             <th>Mode:</th>
                             <td>{{ experiment.mode }}</td>
                         </tr>
+                        {% if experiment.assigned_to %}
                         <tr>
                             <th>Assigned agent:</th>
                             <td>{{ experiment.assigned_to }}</td>
                         </tr>
+                        {% endif %}
+                        {% if experiment.requirement %}
                         <tr>
                             <th>Requirements:</th>
                             <td>{{ experiment.requirement }}</td>
                         </tr>
+                        {% endif %}
                         <tr>
                             <th>Priority:</th>
                             <td>{{ experiment.priority }}</td>

--- a/templates/ui/queue.html
+++ b/templates/ui/queue.html
@@ -10,6 +10,7 @@
                     <tr>
                         <th>Name</th>
                         <th width="20%">Assigned to</th>
+                        <th width="10%">Reqs</th>
                         <th width="15%"class="text-center">Mode</th>
                         <th width="1%" class="text-center">Priority</th>
                         <th width="20%" class="text-center">Status</th>
@@ -17,6 +18,13 @@
                     {% for experiment in experiments %}
                         <tr>
                             <td><a href="/ex/{{ experiment.name }}">{{ experiment.name }}</a></td>
+                            <td>
+                                {% if experiment.requirement %}
+                                    {{ experiment.requirement }}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
                             <td>
                                 {% if experiment.assigned_to %}
                                     {{ experiment.assigned_to }}


### PR DESCRIPTION
Extends #450 to display experiment requirements in the web UI for both the queue (`/`) and the page for each experiment (`/ex/ex-name`). 