### PR TITLE
Log backtraces captured by `failure::Error`

### DIFF
--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -25,7 +25,6 @@ use crate::runner::{
     tasks::{Task, TaskStep},
     RunnerState,
 };
-use failure::AsFail;
 use petgraph::{dot::Dot, graph::NodeIndex, stable_graph::StableDiGraph, Direction};
 use std::fmt::{self, Debug};
 use std::sync::Arc;
@@ -191,14 +190,14 @@ impl TasksGraph {
         self.graph.remove_node(node);
     }
 
-    pub(super) fn mark_as_failed<DB: WriteResults, F: AsFail>(
+    pub(super) fn mark_as_failed<DB: WriteResults>(
         &mut self,
         node: NodeIndex,
         ex: &Experiment,
         db: &DB,
         state: &RunnerState,
         config: &Config,
-        error: &F,
+        error: &failure::Error,
         result: TestResult,
     ) -> Fallible<()> {
         let mut children = self

--- a/src/runner/tasks.rs
+++ b/src/runner/tasks.rs
@@ -6,7 +6,6 @@ use crate::results::{EncodingType, TestResult, WriteResults};
 use crate::runner::{test, RunnerState};
 use crate::toolchain::Toolchain;
 use crate::utils;
-use failure::AsFail;
 use rustwide::{BuildDirectory, Workspace};
 use std::sync::Mutex;
 
@@ -116,13 +115,13 @@ impl Task {
         }
     }
 
-    pub(super) fn mark_as_failed<DB: WriteResults, F: AsFail>(
+    pub(super) fn mark_as_failed<DB: WriteResults>(
         &self,
         ex: &Experiment,
         db: &DB,
         state: &RunnerState,
         config: &Config,
-        err: &F,
+        err: &failure::Error,
         result: TestResult,
     ) -> Fallible<()> {
         match self.step {


### PR DESCRIPTION
Resolves #455.

Previously, `AsFail::as_fail` was being called on `failure::Error` instances passed to `report_failure`. This extracted the underlying error object, but discarded the backtrace stored when the `failure::Error` was constructed. Instead, the `backtrace` method would try to find a backtrace stored in the *underlying* error object, and this usually failed.

This PR adds a `HasBacktrace` trait to extract the backtrace from from the various `failure::Error` and `failure::Context` instances that are passed to `report_failure`. It also prints a message reminding the user to enable backtraces when an error occurs.