### PR TITLE
Extend `CrateSelect` to allow an arbitrary number or explicit list of crates

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -95,6 +95,29 @@ The mode you should use depends on what your experiment is testing:
 
 [Go back to the TOC][h-toc]
 
+## Available crate selections
+
+By default, your experiment will be run on all crates known to Crater.
+However, it is possible to run an experiment on a subset of the ecosystem by
+passing a different value to `crates`. The following options are currently
+available:
+
+* `full`: run the experiment on every crate.
+* `top-{n}`: run the experiment on the `n` most downloaded crates on
+  [crates.io](crates.io) (e.g. `top-100`).
+* `random-{n}`: run the experiment on `n` randomly selected crates (e.g. `random-20`).
+* `list:{...}`: run the experiment on the specified crates.
+
+For `list:`, the value after the colon can either be a comma-separated list of
+crates to run or a link to a newline-separated list of crates ([example][list]).
+For example, `list:lazy_static,brson/hello-rs` and `list:https://git.io/Jes7o`
+will both run an experiment on the `lazy_static` crate and the git repo at
+`github.com/brson/hello-rs`. A link must begin with `http[s]://`.
+
+[list]: https://gist.githubusercontent.com/ecstatic-morse/837c558b63fc73ab469bfbf4ad419a1f/raw/example-crate-list
+
+[Go back to the TOC][h-toc]
+
 ## Automatic experiment names
 
 [h-experiment-names]: #automatic-experiment-names

--- a/src/actions/experiments/create.rs
+++ b/src/actions/experiments/create.rs
@@ -50,7 +50,7 @@ impl Action for CreateExperiment {
             return Err(ExperimentError::DuplicateToolchains.into());
         }
 
-        let crates = crate::crates::lists::get_crates(self.crates, &ctx.db, &ctx.config)?;
+        let crates = crate::crates::lists::get_crates(&self.crates, &ctx.db, &ctx.config)?;
 
         ctx.db.transaction(|transaction| {
             transaction.execute(
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(ex.mode, Mode::BuildAndTest);
         assert_eq!(
             ex.get_crates(&ctx.db).unwrap(),
-            crate::crates::lists::get_crates(CrateSelect::Local, &db, &config).unwrap()
+            crate::crates::lists::get_crates(&CrateSelect::Local, &db, &config).unwrap()
         );
         assert_eq!(ex.cap_lints, CapLints::Forbid);
         assert_eq!(ex.github_issue.as_ref().unwrap().api_url.as_str(), api_url);

--- a/src/actions/experiments/edit.rs
+++ b/src/actions/experiments/edit.rs
@@ -79,7 +79,7 @@ impl Action for EditExperiment {
             // This is also done if ignore_blacklist is changed to recalculate the skipped crates
             let new_crates = if let Some(crates) = self.crates {
                 Some(crate::crates::lists::get_crates(
-                    crates,
+                    &crates,
                     &ctx.db,
                     &ctx.config,
                 )?)
@@ -242,7 +242,7 @@ mod tests {
 
         assert_eq!(
             ex.get_crates(&ctx.db).unwrap(),
-            crate::crates::lists::get_crates(CrateSelect::Local, &db, &config).unwrap()
+            crate::crates::lists::get_crates(&CrateSelect::Local, &db, &config).unwrap()
         );
     }
 

--- a/src/actions/experiments/edit.rs
+++ b/src/actions/experiments/edit.rs
@@ -199,7 +199,7 @@ mod tests {
             name: "foo".to_string(),
             toolchains: ["stable".parse().unwrap(), "beta".parse().unwrap()],
             mode: Mode::BuildAndTest,
-            crates: CrateSelect::SmallRandom,
+            crates: CrateSelect::Random(20),
             cap_lints: CapLints::Forbid,
             priority: 0,
             github_issue: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ use crater::agent::{self, Capabilities};
 use crater::config::Config;
 use crater::crates::Crate;
 use crater::db::Database;
-use crater::experiments::{Assignee, CapLints, CrateSelect, Experiment, Mode, Status};
+use crater::experiments::{Assignee, CapLints, DeferredCrateSelect, Experiment, Mode, Status};
 use crater::report;
 use crater::results::{DatabaseDB, DeleteResults};
 use crater::runner;
@@ -125,7 +125,7 @@ pub enum Crater {
                          by a comma-separated list of crates.",
             raw(default_value = "\"demo\"",)
         )]
-        crates: CrateSelect,
+        crates: DeferredCrateSelect,
         #[structopt(
             name = "level",
             long = "cap-lints",
@@ -168,7 +168,7 @@ pub enum Crater {
                          where {d} is a positive integer, or \"list:\" followed \
                          by a comma-separated list of crates."
         )]
-        crates: Option<CrateSelect>,
+        crates: Option<DeferredCrateSelect>,
         #[structopt(
             name = "cap-lints",
             long = "cap-lints",
@@ -366,7 +366,7 @@ impl Crater {
                     name: ex.0.clone(),
                     toolchains: [tc1.clone(), tc2.clone()],
                     mode: *mode,
-                    crates: crates.clone(),
+                    crates: crates.clone().resolve()?,
                     cap_lints: *cap_lints,
                     priority: *priority,
                     github_issue: None,
@@ -405,7 +405,7 @@ impl Crater {
                     name: name.clone(),
                     toolchains: [tc1.clone(), tc2.clone()],
                     mode: *mode,
-                    crates: crates.clone(),
+                    crates: crates.clone().map(|cs| cs.resolve()).transpose()?,
                     cap_lints: *cap_lints,
                     priority: *priority,
                     ignore_blacklist,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,10 +118,12 @@ pub enum Crater {
         #[structopt(
             name = "crate-select",
             long = "crate-select",
-            raw(
-                default_value = "CrateSelect::Demo.to_str()",
-                possible_values = "CrateSelect::possible_values()"
-            )
+            help = "The set of crates on which the experiment will run.",
+            long_help = "The set of crates on which the experiment will run.\n\n\
+                         This can be one of (full, demo, random-{d}, top-{d}, local) \
+                         where {d} is a positive integer, or \"list:\" followed \
+                         by a comma-separated list of crates.",
+            raw(default_value = "\"demo\"",)
         )]
         crates: CrateSelect,
         #[structopt(
@@ -160,7 +162,11 @@ pub enum Crater {
         #[structopt(
             name = "crates",
             long = "crates",
-            raw(possible_values = "CrateSelect::possible_values()")
+            help = "The set of crates on which the experiment will run.",
+            long_help = "The set of crates on which the experiment will run.\n\n\
+                         This can be one of (full, demo, random-{d}, top-{d}, local) \
+                         where {d} is a positive integer, or \"list:\" followed \
+                         by a comma-separated list of crates."
         )]
         crates: Option<CrateSelect>,
         #[structopt(
@@ -360,7 +366,7 @@ impl Crater {
                     name: ex.0.clone(),
                     toolchains: [tc1.clone(), tc2.clone()],
                     mode: *mode,
-                    crates: *crates,
+                    crates: crates.clone(),
                     cap_lints: *cap_lints,
                     priority: *priority,
                     github_issue: None,
@@ -399,7 +405,7 @@ impl Crater {
                     name: name.clone(),
                     toolchains: [tc1.clone(), tc2.clone()],
                     mode: *mode,
-                    crates: *crates,
+                    crates: crates.clone(),
                     cap_lints: *cap_lints,
                     priority: *priority,
                     ignore_blacklist,

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,7 +146,7 @@ impl Config {
         let mut has_errors = Self::check_for_dup_keys(&buffer).is_err();
         let cfg: Self = ::toml::from_str(&buffer)?;
         let db = crate::db::Database::open()?;
-        let crates = crate::crates::lists::get_crates(CrateSelect::Full, &db, &cfg)?;
+        let crates = crate::crates::lists::get_crates(&CrateSelect::Full, &db, &cfg)?;
         has_errors |= cfg.check_for_missing_crates(&crates).is_err();
         has_errors |= cfg.check_for_missing_repos(&crates).is_err();
         if has_errors {

--- a/src/crates/lists.rs
+++ b/src/crates/lists.rs
@@ -63,7 +63,7 @@ pub(crate) trait List {
 }
 
 pub(crate) fn get_crates(
-    select: CrateSelect,
+    select: &CrateSelect,
     db: &Database,
     config: &Config,
 ) -> Fallible<Vec<Crate>> {

--- a/src/crates/lists.rs
+++ b/src/crates/lists.rs
@@ -12,8 +12,6 @@ pub(crate) use crate::crates::sources::{
     github::GitHubList, local::LocalList, registry::RegistryList,
 };
 
-const SMALL_RANDOM_COUNT: usize = 20;
-
 pub(crate) trait List {
     const NAME: &'static str;
 
@@ -74,6 +72,7 @@ pub(crate) fn get_crates(
             crates.append(&mut RegistryList::get(db)?);
             crates.append(&mut GitHubList::get(db)?);
         }
+
         CrateSelect::Demo => {
             let mut demo_registry = config.demo_crates().crates.iter().collect::<HashSet<_>>();
             let mut demo_github = config
@@ -115,17 +114,41 @@ pub(crate) fn get_crates(
                 bail!("missing demo local crates: {:?}", demo_local);
             }
         }
-        CrateSelect::SmallRandom => {
+        CrateSelect::List(list) => {
+            let mut desired = list.clone();
+
+            let mut all_crates = Vec::new();
+            all_crates.append(&mut RegistryList::get(db)?);
+            all_crates.append(&mut GitHubList::get(db)?);
+
+            for krate in all_crates {
+                let is_desired = match krate {
+                    Crate::Registry(RegistryCrate { ref name, .. }) => desired.remove(name),
+                    Crate::GitHub(ref repo) => desired.remove(&repo.slug()),
+                    _ => unreachable!(),
+                };
+
+                if is_desired {
+                    crates.push(krate);
+                }
+            }
+
+            if !desired.is_empty() {
+                bail!("missing desired crates: {:?}", desired);
+            }
+        }
+
+        CrateSelect::Random(n) => {
             crates.append(&mut RegistryList::get(db)?);
             crates.append(&mut GitHubList::get(db)?);
 
             let mut rng = thread_rng();
             rng.shuffle(&mut crates);
-            crates.truncate(SMALL_RANDOM_COUNT);
+            crates.truncate(*n as usize);
         }
-        CrateSelect::Top100 => {
+        CrateSelect::Top(n) => {
             crates.append(&mut RegistryList::get(db)?);
-            crates.truncate(100);
+            crates.truncate(*n as usize);
         }
         CrateSelect::Local => {
             crates.append(&mut LocalList::get(db)?);

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -27,21 +27,59 @@ string_enum!(pub enum Mode {
     UnstableFeatures => "unstable-features",
 });
 
-string_enum!(pub enum CrateSelect {
-    Full => "full",
-    Demo => "demo",
-    SmallRandom => "small-random",
-    Top100 => "top-100",
-    Local => "local",
-    Dummy => "dummy",
-});
-
 string_enum!(pub enum CapLints {
     Allow => "allow",
     Warn => "warn",
     Deny => "deny",
     Forbid => "forbid",
 });
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub enum CrateSelect {
+    Full,
+    Demo,
+    SmallRandom,
+    Top100,
+    Local,
+    Dummy,
+}
+
+impl FromStr for CrateSelect {
+    type Err = failure::Error;
+
+    fn from_str(s: &str) -> failure::Fallible<Self> {
+        let ret = match s {
+            "full" => Self::Full,
+            "demo" => Self::Demo,
+            "small-random" => Self::SmallRandom,
+            "top-100" => Self::Top100,
+            "local" => Self::Local,
+            "dummy" => Self::Dummy,
+            s => bail!("invalid CrateSelect: {}", s),
+        };
+
+        Ok(ret)
+    }
+}
+
+impl CrateSelect {
+    pub fn to_str(&self) -> &'static str {
+        match *self {
+            Self::Full => "full",
+            Self::Demo => "demo",
+            Self::SmallRandom => "small-random",
+            Self::Top100 => "top-100",
+            Self::Local => "local",
+            Self::Dummy => "dummy",
+        }
+    }
+
+    pub fn possible_values() -> &'static [&'static str] {
+        &["full", "demo", "small-random", "top-100", "local", "dummy"]
+    }
+}
+
+impl_serde_from_parse!(CrateSelect, expecting = "A valid value of `CrateSelect`");
 
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -1,9 +1,9 @@
-use chrono::{DateTime, Utc};
 use crate::crates::Crate;
 use crate::db::{Database, QueryUtils};
 use crate::prelude::*;
 use crate::toolchain::Toolchain;
 use crate::utils;
+use chrono::{DateTime, Utc};
 use rusqlite::Row;
 use serde_json;
 use std::collections::HashSet;
@@ -120,10 +120,7 @@ impl CrateSelect {
             bail!("Crate identifiers must not contain a comma");
         }
 
-        let crates = s
-            .split_whitespace()
-            .map(|s| s.to_owned())
-            .collect();
+        let crates = s.split_whitespace().map(|s| s.to_owned()).collect();
         Ok(CrateSelect::List(crates))
     }
 }
@@ -570,7 +567,9 @@ impl ExperimentDBRecord {
 
 #[cfg(test)]
 mod tests {
-    use super::{Assignee, AssigneeParseError, CrateSelect, DeferredCrateSelect, Experiment, Status};
+    use super::{
+        Assignee, AssigneeParseError, CrateSelect, DeferredCrateSelect, Experiment, Status,
+    };
     use crate::actions::{Action, ActionsCtx, CreateExperiment};
     use crate::agent::Capabilities;
     use crate::config::Config;
@@ -592,7 +591,10 @@ mod tests {
             ("top-25", CrateSelect::Top(25)),
             ("random-87", CrateSelect::Random(87)),
             ("small-random", CrateSelect::Random(20)),
-            ("list:brson/hello-rs,lazy_static", CrateSelect::List(demo_crates.clone())),
+            (
+                "list:brson/hello-rs,lazy_static",
+                CrateSelect::List(demo_crates.clone()),
+            ),
         ];
 
         for (s, output) in suite.into_iter() {
@@ -613,11 +615,13 @@ mod tests {
             DeferredCrateSelect::Indirect("https://git.io/Jes7o".parse().unwrap()),
         );
 
-        let list = CrateSelect::from_newline_separated_list(r"
+        let list = CrateSelect::from_newline_separated_list(
+            r"
             brson/hello-rs
 
-            lazy_static"
-        ).unwrap();
+            lazy_static",
+        )
+        .unwrap();
 
         assert_eq!(list, CrateSelect::List(demo_crates));
     }

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -1,5 +1,52 @@
 use crate::experiments::{Assignee, CapLints, CrateSelect, Mode};
 use crate::toolchain::Toolchain;
+use failure::{self, Fallible};
+use reqwest;
+use url::Url;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum DeferredCrateSelect {
+    Direct(CrateSelect),
+    Indirect(Url),
+}
+
+impl From<CrateSelect> for DeferredCrateSelect {
+    fn from(v: CrateSelect) -> Self {
+        DeferredCrateSelect::Direct(v)
+    }
+}
+
+impl DeferredCrateSelect {
+    pub fn resolve(self) -> Fallible<CrateSelect> {
+        let url = match self {
+            DeferredCrateSelect::Direct(v) => return Ok(v),
+            DeferredCrateSelect::Indirect(url) => url,
+        };
+
+        let body = reqwest::get(url)?.text()?;
+        if body.contains(',') {
+            bail!("Crate identifiers must not contain a comma");
+        }
+
+        let crates = body
+            .split(|c: char| c.is_whitespace())
+            .map(|s| s.to_owned())
+            .collect();
+        Ok(CrateSelect::List(crates))
+    }
+}
+
+impl FromStr for DeferredCrateSelect {
+    type Err = failure::Error;
+
+    fn from_str(input: &str) -> Fallible<Self> {
+        if input.starts_with("https://") || input.starts_with("http://") {
+            Ok(DeferredCrateSelect::Indirect(input.parse()?))
+        } else {
+            Ok(DeferredCrateSelect::Direct(input.parse()?))
+        }
+    }
+}
 
 #[derive(Debug, Fail)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
@@ -107,7 +154,7 @@ generate_parser!(pub enum Command {
         start: Option<Toolchain> = "start",
         end: Option<Toolchain> = "end",
         mode: Option<Mode> = "mode",
-        crates: Option<CrateSelect> = "crates",
+        crates: Option<DeferredCrateSelect> = "crates",
         cap_lints: Option<CapLints> = "cap-lints",
         priority: Option<i32> = "p",
         ignore_blacklist: Option<bool> = "ignore-blacklist",
@@ -148,7 +195,7 @@ generate_parser!(pub enum Command {
         start: Option<Toolchain> = "start",
         end: Option<Toolchain> = "end",
         mode: Option<Mode> = "mode",
-        crates: Option<CrateSelect> = "crates",
+        crates: Option<DeferredCrateSelect> = "crates",
         cap_lints: Option<CapLints> = "cap-lints",
         priority: Option<i32> = "p",
         ignore_blacklist: Option<bool> = "ignore-blacklist",

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -120,7 +120,7 @@ generate_parser!(pub enum Command {
         name: Option<String> = "name",
         start: Option<Toolchain> = "start",
         end: Option<Toolchain> = "end",
-        crates: Option<CrateSelect> = "crates",
+        crates: Option<DeferredCrateSelect> = "crates",
         cap_lints: Option<CapLints> = "cap-lints",
         priority: Option<i32> = "p",
         ignore_blacklist: Option<bool> = "ignore-blacklist",


### PR DESCRIPTION
Resolves #460.

Make `CrateSelect` take an arbitrary number as part of a `top-{n}` or `random-{n}` crate specification or a  comma-separated list of crates. Also allows craterbot comments to specify a list of crates via a URL (e.g. crates=https://gist.githubusercontent.com/ecstatic-morse/837c558b63fc73ab469bfbf4ad419a1f/raw/example-crate-list). 