### PR TITLE
Switch to using normal, non-alt builds

### DIFF
--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -38,7 +38,7 @@ pub fn run(
             detected_start = Some(Toolchain {
                 source: RustwideToolchain::CI {
                     sha: build.base_sha.into(),
-                    alt: true,
+                    alt: false,
                 },
                 rustflags: None,
                 ci_try: false,
@@ -46,7 +46,7 @@ pub fn run(
             detected_end = Some(Toolchain {
                 source: RustwideToolchain::CI {
                     sha: build.merge_sha.into(),
-                    alt: true,
+                    alt: false,
                 },
                 rustflags: None,
                 ci_try: true,

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -101,12 +101,12 @@ impl FromStr for Toolchain {
                     ci_try = true;
                     RustwideToolchain::CI {
                         sha: Cow::Owned(sha),
-                        alt: true,
+                        alt: false,
                     }
                 }
                 "master" => RustwideToolchain::CI {
                     sha: Cow::Owned(sha),
-                    alt: true,
+                    alt: false,
                 },
                 name => return Err(ToolchainParseError::InvalidSourceName(name.to_string())),
             }
@@ -206,14 +206,14 @@ mod tests {
             "master#0000000000000000000000000000000000000000" => {
                 source: RustwideToolchain::CI {
                     sha: "0000000000000000000000000000000000000000".into(),
-                    alt: true,
+                    alt: false,
                 },
                 ci_try: false,
             },
             "try#0000000000000000000000000000000000000000" => {
                 source: RustwideToolchain::CI {
                     sha: "0000000000000000000000000000000000000000".into(),
-                    alt: true,
+                    alt: false,
                 },
                 ci_try: true,
             },


### PR DESCRIPTION
This should be faster for non-check builds.

r? @pietroalbini 