### PR TITLE
Add patch flag to toolchains

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -111,6 +111,16 @@ capability `windows`. You must specify a requirement for your experiment
 (either `linux` or `windows`), and your experiment will only run on agents with
 that capability.
 
+### Specifying Toolchains
+
+Crater allows some configurations to the toolchains used in an experiment.
+You can specify a toolchain using a rustup name or `branch#sha`, and use the
+following flags:
+* `+rustflags={flags}`: sets the `RUSTFLAGS` environment variable to `{flags}` when
+  building with this toolchain
+* `+patch={crate_name}={git_repo_url}={branch}`: patches all crates built by
+  this toolchain to resolve the given crate from the given git repository and branch.
+
 ## Commands reference
 
 ### Creating experiments
@@ -126,10 +136,10 @@ beta run you can use:
 
 * `name`: name of the experiment; required only if Crater [can't determine it
   automatically][h-experiment-names]
-* `start`: name of the first toolchain; can be either a rustup name or
-  `branch#sha` (required if no try build is automatically detected)
-* `end`: name of the second toolchain; can be either a rustup name or
-  `branch#sha` (required if no try build is automatically detected)
+* `start`: the first toolchain; see [specifying toolchains](#specifying-toolchains)
+  (required if no try build is automatically detected)
+* `end`: the second toolchain; see [specifying toolchains](#specifying-toolchains)
+  (required if no try build is automatically detected)
 * `mode`: the experiment mode (default: `build-and-test`)
 * `crates`: the selection of crates to use (default: `full`)
 * `cap-lints`: the lints cap (default: `forbid`, which means no cap)
@@ -155,10 +165,10 @@ priority of the `foo` experiment you can use:
 
 * `name`: name of the experiment; required only if Crater [can't determine it
   automatically][h-experiment-names]
-* `start`: name of the first toolchain; can be either a rustup name or
-  `branch#sha` (required)
-* `end`: name of the second toolchain; can be either a rustup name or
-  `branch#sha` (required)
+* `start`: the first toolchain; see [specifying toolchains](#specifying-toolchains)
+  (required if no try build is automatically detected)
+* `end`: the second toolchain; see [specifying toolchains](#specifying-toolchains)
+  (required if no try build is automatically detected)
 * `mode`: the experiment mode (default: `build-and-test`)
 * `crates`: the selection of crates to use (default: `full`)
 * `cap-lints`: the lints cap (default: `forbid`, which means no cap)

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -42,6 +42,7 @@ pub fn run(
                 },
                 rustflags: None,
                 ci_try: false,
+                patches: Vec::new(),
             });
             detected_end = Some(Toolchain {
                 source: RustwideToolchain::CI {
@@ -50,6 +51,7 @@ pub fn run(
                 },
                 rustflags: None,
                 ci_try: true,
+                patches: Vec::new(),
             });
         }
     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -172,7 +172,11 @@ impl FromStr for CratePatch {
         if params.len() != 3 {
             Err(ToolchainParseError::InvalidFlag(input.to_string()))
         } else {
-            Ok(CratePatch { name: params[0].into(), repo: params[1].into(), branch: params[2].into() })
+            Ok(CratePatch {
+                name: params[0].into(),
+                repo: params[1].into(),
+                branch: params[2].into(),
+            })
         }
     }
 }
@@ -182,7 +186,6 @@ impl fmt::Display for CratePatch {
         write!(f, "{}={}={}", self.name, self.repo, self.branch)
     }
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR adds the feature detailed in #441 

A toolchain can be specified with a patch flag in the format `+patch={crate-name}={git-repo}={branch}` and will result in a patch section being added to the `Cargo.toml` of all crates built by the toolchain.

For example, a toolchain specified as `stable+patch=example=https://git.example.com/repo=master` will result in the following section being added to all crate's `Cargo.toml`s:
```toml
[patch.crates-io]
example = { git = "https://git.example.com/repo", branch = "master" }
```