### PR TITLE
Fix order of fields on homepage

### DIFF
--- a/templates/ui/queue.html
+++ b/templates/ui/queue.html
@@ -19,15 +19,15 @@
                         <tr>
                             <td><a href="/ex/{{ experiment.name }}">{{ experiment.name }}</a></td>
                             <td>
-                                {% if experiment.requirement %}
-                                    {{ experiment.requirement }}
+                                {% if experiment.assigned_to %}
+                                    {{ experiment.assigned_to }}
                                 {% else %}
                                     -
                                 {% endif %}
                             </td>
                             <td>
-                                {% if experiment.assigned_to %}
-                                    {{ experiment.assigned_to }}
+                                {% if experiment.requirement %}
+                                    {{ experiment.requirement }}
                                 {% else %}
                                     -
                                 {% endif %}


### PR DESCRIPTION
After #454, the `Assigned to` and `Reqs` fields are swapped on [crater.rust-lang.org](http://crater.rust-lang.org). I'm, uh, not proud of this one.