### PR TITLE
Add 'check' command shorthand.

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -40,8 +40,16 @@ toolchain. You can do that with the `@bors try` GitHub comment.
 use][h-experiment-modes] and type up the command in your GitHub PR:
 
 ```
-@craterbot run mode=YOUR-MODE
+@craterbot check
 ```
+
+This is a shorthand for:
+
+```
+@craterbot run mode=check-only
+```
+
+For more on available modes, [read on][h-experiment-modes].
 
 If you don't want to do a Crater run with the last try build but with an older
 one, you need to get the SHA of the start and end commits. Bors should have

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -115,6 +115,18 @@ generate_parser!(pub enum Command {
         requirement: Option<String> = "requirement",
     })
 
+    "check" => Check(CheckArgs {
+        name: Option<String> = "name",
+        start: Option<Toolchain> = "start",
+        end: Option<Toolchain> = "end",
+        crates: Option<CrateSelect> = "crates",
+        cap_lints: Option<CapLints> = "cap-lints",
+        priority: Option<i32> = "p",
+        ignore_blacklist: Option<bool> = "ignore-blacklist",
+        assign: Option<Assignee> = "assign",
+        requirement: Option<String> = "requirement",
+    })
+
     "abort" => Abort(AbortArgs {
         name: Option<String> = "name",
     })

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::server::github::{Issue, Repository};
 use crate::server::messages::{Label, Message};
 use crate::server::routes::webhooks::args::{
-    AbortArgs, EditArgs, RetryArgs, RetryReportArgs, RunArgs,
+    AbortArgs, CheckArgs, EditArgs, RetryArgs, RetryReportArgs, RunArgs,
 };
 use crate::server::Data;
 use crate::toolchain::Toolchain;
@@ -17,6 +17,33 @@ pub fn ping(data: &Data, issue: &Issue) -> Fallible<()> {
         .send(&issue.url, data)?;
 
     Ok(())
+}
+
+pub fn check(
+    host: &str,
+    data: &Data,
+    repo: &Repository,
+    issue: &Issue,
+    args: CheckArgs,
+) -> Fallible<()> {
+    run(
+        host,
+        data,
+        repo,
+        issue,
+        RunArgs {
+            mode: Some(Mode::CheckOnly),
+            name: args.name,
+            start: args.start,
+            end: args.end,
+            crates: args.crates,
+            cap_lints: args.cap_lints,
+            priority: args.priority,
+            ignore_blacklist: args.ignore_blacklist,
+            assign: args.assign,
+            requirement: args.requirement,
+        },
+    )
 }
 
 pub fn run(
@@ -473,7 +500,7 @@ mod tests {
         assert_eq!(new_name, "pr-12345-1");
         actions::CreateExperiment::dummy("pr-12345-1")
             .apply(&ctx)
-            .expect("could not store dummy experiment");;
+            .expect("could not store dummy experiment");
         assert_eq!(
             &generate_new_experiment_name(&db, &pr).unwrap(),
             "pr-12345-2"

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -120,6 +120,10 @@ fn process_command(
                 commands::run(host, data, repo, issue, args)?;
             }
 
+            Command::Check(args) => {
+                commands::check(host, data, repo, issue, args)?;
+            }
+
             Command::Edit(args) => {
                 commands::edit(data, issue, args)?;
             }


### PR DESCRIPTION
Allows you to write `@craterbot check` instead of `@craterbot run mode=check-only` which is what you want almost always.

Fixes https://github.com/rust-lang/crater/issues/416.

r? @pietroalbini 