### PR TITLE
agent: purge build directories only on new experiments

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -61,19 +61,6 @@ pub fn run_ex<DB: WriteResults + Sync>(
         return Err(err_msg("docker is not running"));
     }
 
-    let res = run_ex_inner(ex, workspace, crates, db, threads_count, config);
-    workspace.purge_all_build_dirs()?;
-    res
-}
-
-fn run_ex_inner<DB: WriteResults + Sync>(
-    ex: &Experiment,
-    workspace: &Workspace,
-    crates: &[Crate],
-    db: &DB,
-    threads_count: usize,
-    config: &Config,
-) -> Fallible<()> {
     info!("computing the tasks graph...");
     let graph = Mutex::new(build_graph(ex, crates, config));
 


### PR DESCRIPTION
Before this commit, the agent purged the build directories every time an
experiment was started. This was fine before distributed experiments
were introduced, but it clashed with them as distributed experiments are
implemented as tons of little sub-experiments.

Because of that the build directories were purged every 32 crates,
hurting build caches a lot. This commit changes the agent to purge build
directories both when it's started and when starting to test an
experiment with a name different than the previous one.