### PR TITLE
scrape metrics to collect agents who worked on a specific experiment

### DIFF
--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
+use prometheus::proto::{Metric, MetricFamily};
 use prometheus::{IntCounterVec, __register_counter_vec};
+const JOBS_METRIC: &str = "crater_completed_jobs_total";
 
 #[derive(Clone)]
 pub struct Metrics {
@@ -8,7 +10,7 @@ pub struct Metrics {
 
 impl Metrics {
     pub fn new() -> Fallible<Self> {
-        let opts = prometheus::opts!("crater_completed_jobs_total", "total completed jobs");
+        let opts = prometheus::opts!(JOBS_METRIC, "total completed jobs");
         let crater_completed_jobs_total =
             prometheus::register_int_counter_vec!(opts, &["agent", "experiment"])?;
         Ok(Metrics {
@@ -22,37 +24,52 @@ impl Metrics {
             .inc_by(amount);
     }
 
-    fn remove_experiment_jobs(&self, experiment: &str, agents: &[&str]) -> Fallible<()> {
-        for agent in agents.iter() {
-            self.crater_completed_jobs_total
-                .remove_label_values(&[agent, &experiment])?;
+    fn get_metric_by_name(name: &str) -> Option<MetricFamily> {
+        let families = prometheus::gather();
+        families.into_iter().find(|fam| fam.get_name() == name)
+    }
+
+    fn get_label_by_name<'a>(metric: &'a Metric, label: &str) -> Option<&'a str> {
+        metric
+            .get_label()
+            .iter()
+            .find(|lab| lab.get_name() == label)
+            .map(|lab| lab.get_value())
+    }
+
+    fn remove_experiment_jobs(&self, experiment: &str) -> Fallible<()> {
+        if let Some(metric) = Self::get_metric_by_name(JOBS_METRIC) {
+            let agents = metric
+                .get_metric()
+                .iter()
+                .filter(|met| Self::get_label_by_name(met, "experiment").unwrap() == experiment)
+                .map(|met| Self::get_label_by_name(met, "agent").unwrap())
+                .collect::<Vec<&str>>();
+
+            for agent in agents.iter() {
+                self.crater_completed_jobs_total
+                    .remove_label_values(&[agent, &experiment])?;
+            }
         }
+
         Ok(())
     }
 
-    pub fn on_complete_experiment(&self, experiment: &str, agents: &[&str]) -> Fallible<()> {
-        self.remove_experiment_jobs(experiment, agents)
+    pub fn on_complete_experiment(&self, experiment: &str) -> Fallible<()> {
+        self.remove_experiment_jobs(experiment)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Metrics;
+    use super::{Metrics, JOBS_METRIC};
     use prometheus::proto::MetricFamily;
 
-    const JOBS_METRIC: &str = "crater_completed_jobs_total";
-
     fn test_experiment_presence(metric: &MetricFamily, experiment: &str) -> bool {
-        metric.get_metric().iter().any(|met| {
-            met.get_label()
-                .iter()
-                .any(|lab| lab.get_name() == "experiment" && lab.get_value() == experiment)
-        })
-    }
-
-    fn get_metric_by_name(name: &str) -> Option<MetricFamily> {
-        let families = prometheus::gather();
-        families.into_iter().find(|fam| fam.get_name() == name)
+        metric
+            .get_metric()
+            .iter()
+            .any(|met| Metrics::get_label_by_name(met, "experiment").unwrap() == experiment)
     }
 
     #[test]
@@ -68,17 +85,19 @@ mod tests {
         metrics.record_completed_jobs(agent2, ex2, 1);
 
         //test metrics are correctly registered
-        let jobs = get_metric_by_name(JOBS_METRIC).unwrap();
+        let jobs = Metrics::get_metric_by_name(JOBS_METRIC).unwrap();
         assert!(test_experiment_presence(&jobs, ex1));
         assert!(test_experiment_presence(&jobs, ex2));
 
         //test metrics are correctly removed when an experiment is completed
-        metrics
-            .on_complete_experiment(ex1, &[agent2, agent1])
-            .unwrap();
+        metrics.on_complete_experiment(ex1).unwrap();
 
-        let jobs = get_metric_by_name(JOBS_METRIC).unwrap();
+        let jobs = Metrics::get_metric_by_name(JOBS_METRIC).unwrap();
         assert!(!test_experiment_presence(&jobs, ex1));
         assert!(test_experiment_presence(&jobs, ex2));
+
+        //test nothing bad happens when a specific
+        //experiment is executed by a subset of the agents
+        metrics.on_complete_experiment(ex2).unwrap();
     }
 }

--- a/src/server/reports.rs
+++ b/src/server/reports.rs
@@ -27,15 +27,7 @@ fn generate_report(data: &Data, ex: &Experiment, results: &DatabaseDB) -> Fallib
     let res = report::gen(results, &ex, &crates, &writer, &data.config)?;
 
     //remove metrics about completed experiments
-    data.metrics.on_complete_experiment(
-        &ex.name,
-        &data
-            .agents
-            .all()?
-            .iter()
-            .map(|agent| agent.name())
-            .collect::<Vec<&str>>(),
-    )?;
+    data.metrics.on_complete_experiment(&ex.name)?;
 
     Ok(res)
 }


### PR DESCRIPTION
`remove_label_values` returns an error when the label values are not present in the metrics, this pr fixes the previous implementation.