### PR TITLE
server: allow retrying reports when they're stuck in progress

### DIFF
--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -171,7 +171,9 @@ pub fn retry_report(data: &Data, issue: &Issue, args: RetryReportArgs) -> Fallib
     let name = get_name(&data.db, issue, args.name)?;
 
     if let Some(mut experiment) = Experiment::get(&data.db, &name)? {
-        if experiment.status != Status::ReportFailed {
+        if experiment.status != Status::ReportFailed
+            && experiment.status != Status::GeneratingReport
+        {
             bail!(
                 "generation of the report of the **`{}`** experiment didn't fail!",
                 name


### PR DESCRIPTION
We had a Crater issue in the weekend where report generation was stuck. To fix it I had to manually log into the server and change the status of the experiment to `report-failed`, allowing `@craterbot retry-report` to work. This commit changes the `retry-report` command to allow retrying stuck reports as well, removing the need to tweak the database.