### PR TITLE
experiments: fix failed experiment being returned

### DIFF
--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -284,7 +284,8 @@ impl Experiment {
             "SELECT * FROM experiments \
              INNER JOIN experiment_crates ON experiment_crates.experiment \
              = experiments.name WHERE experiment_crates.assigned_to = ?1 \
-             AND experiment_crates.status = ?2  AND experiment_crates.skipped = 0 LIMIT 1",
+             AND experiment_crates.status = ?2 AND experiments.status = ?2 \
+             AND experiment_crates.skipped = 0 LIMIT 1",
             &[&assignee.to_string(), Status::Running.to_str()],
             |r| ExperimentDBRecord::from_row(r),
         )?;


### PR DESCRIPTION
We had an issue a few days ago where an experiment failed to start (due to a wrong rustup toolchain name), and the server kept assigning it to agents even though it was marked as failed. That caused hundreds of comments being posted on the GitHub issue, before the experiment was aborted.

This PR fixes the issue by ensuring the experiment's status is "running" before giving it to agents.

r? @Zeegomo 