### PR TITLE
Display counts for individual result types in experiment view

### DIFF
--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::crates::Crate;
 use crate::db::{Database, QueryUtils};
 use crate::prelude::*;
+use crate::results::TestResult;
 use crate::toolchain::Toolchain;
 use crate::utils;
 use chrono::{DateTime, Utc};
@@ -556,6 +557,17 @@ impl Experiment {
             .unwrap();
 
         Ok((results_len, crates_len * 2))
+    }
+
+    pub fn get_result_counts(&self, db: &Database) -> Fallible<Vec<(TestResult, u32)>> {
+        let results: Vec<Fallible<(TestResult, u32)>> = db.query(
+            "SELECT result, COUNT(*) FROM results \
+             WHERE experiment = ?1 GROUP BY result;",
+            &[&self.name.as_str()],
+            |r| Ok((TestResult::from_str(&r.get::<_, String>(0))?, r.get(1))),
+        )?;
+
+        results.into_iter().collect()
     }
 
     pub fn progress(&self, db: &Database) -> Fallible<u8> {

--- a/src/server/routes/ui/experiments.rs
+++ b/src/server/routes/ui/experiments.rs
@@ -1,5 +1,6 @@
 use crate::experiments::{Experiment, Mode, Status};
 use crate::prelude::*;
+use crate::results::TestResult;
 use crate::server::routes::ui::{render_template, LayoutContext};
 use crate::server::{Data, HttpError};
 use chrono::{Duration, SecondsFormat, Utc};
@@ -120,6 +121,7 @@ struct ExperimentExt {
 
     total_jobs: u32,
     completed_jobs: u32,
+    result_counts: Vec<(TestResult, u32)>,
     duration: Option<String>,
     estimated_end: Option<String>,
     average_job_duration: Option<String>,
@@ -134,6 +136,7 @@ struct ExperimentContext {
 pub fn endpoint_experiment(name: String, data: Arc<Data>) -> Fallible<Response<Body>> {
     if let Some(ex) = Experiment::get(&data.db, &name)? {
         let (completed_jobs, total_jobs) = ex.raw_progress(&data.db)?;
+        let result_counts = ex.get_result_counts(&data.db)?;
 
         let (duration, estimated_end, average_job_duration) = if completed_jobs > 0
             && total_jobs > 0
@@ -189,6 +192,7 @@ pub fn endpoint_experiment(name: String, data: Arc<Data>) -> Fallible<Response<B
 
             total_jobs,
             completed_jobs,
+            result_counts,
             duration,
             estimated_end,
             average_job_duration,

--- a/templates/ui/experiment.html
+++ b/templates/ui/experiment.html
@@ -104,6 +104,12 @@
                             <td>{{ experiment.average_job_duration }}</td>
                         </tr>
                         {% endif %}
+                        {% for result_count in experiment.result_counts %}
+                        <tr>
+                            <th>{{ result_count.0 }} jobs:</th>
+                            <td>{{ result_count.1}}</td>
+                        </tr>
+                        {% endfor %}
                     </table>
                 </div>
             </div>

--- a/templates/ui/experiment.html
+++ b/templates/ui/experiment.html
@@ -104,14 +104,20 @@
                             <td>{{ experiment.average_job_duration }}</td>
                         </tr>
                         {% endif %}
-                        {% for result_count in experiment.result_counts %}
-                        <tr>
-                            <th>{{ result_count.0 }} jobs:</th>
-                            <td>{{ result_count.1}}</td>
-                        </tr>
-                        {% endfor %}
                     </table>
                 </div>
+                {% if experiment.result_counts | length > 0 %}
+                <div class="card">
+                    <table class="details">
+                {% for result_count in experiment.result_counts %}
+                    <tr>
+                        <th>{{ result_count.0 }} jobs:</th>
+                        <td>{{ result_count.1}}</td>
+                    </tr>
+                {% endfor %}
+                    </table>
+                </div>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This allows users to get an idea of how an experiment is progressing,
without needing to wait mutliple days to see the final report.