### PR TITLE
Add generation of "retry regressed" list

### DIFF
--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -807,7 +807,7 @@ mod tests {
     #[test]
     fn test_crate_select_parsing() {
         let demo_crates: HashSet<_> = ["brson/hello-rs", "lazy_static"]
-            .into_iter()
+            .iter()
             .map(|s| s.to_string())
             .collect();
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -711,6 +711,10 @@ mod tests {
             name: "hello-rs".into(),
         };
         let gh = Crate::GitHub(repo.clone());
+        let reg = Crate::Registry(RegistryCrate {
+            name: "syn".into(),
+            version: "1.0.0".into(),
+        });
 
         let ex = Experiment {
             name: "foo".to_string(),
@@ -756,8 +760,33 @@ mod tests {
             EncodedLog::Plain(b"beta log".to_vec()),
         );
 
+        db.add_dummy_result(
+            &ex,
+            reg.clone(),
+            MAIN_TOOLCHAIN.clone(),
+            TestResult::TestPass,
+        );
+        db.add_dummy_result(
+            &ex,
+            reg.clone(),
+            TEST_TOOLCHAIN.clone(),
+            TestResult::BuildFail(FailureReason::Unknown),
+        );
+        db.add_dummy_log(
+            &ex,
+            reg.clone(),
+            MAIN_TOOLCHAIN.clone(),
+            EncodedLog::Plain(b"stable log".to_vec()),
+        );
+        db.add_dummy_log(
+            &ex,
+            reg.clone(),
+            TEST_TOOLCHAIN.clone(),
+            EncodedLog::Plain(b"beta log".to_vec()),
+        );
+
         let writer = DummyWriter::default();
-        gen(&db, &ex, &[gh], &writer, &config).unwrap();
+        gen(&db, &ex, &[gh, reg], &writer, &config).unwrap();
 
         assert_eq!(
             writer.get("config.json", &mime::APPLICATION_JSON),
@@ -776,30 +805,59 @@ mod tests {
         let result: TestResults =
             serde_json::from_slice(&writer.get("results.json", &mime::APPLICATION_JSON)).unwrap();
 
-        assert_eq!(result.crates.len(), 1);
-        let crate_result = &result.crates[0];
+        assert_eq!(result.crates.len(), 2);
+        let gh_result = &result.crates[0];
+        let reg_result = &result.crates[1];
 
-        assert_eq!(crate_result.name.as_str(), "brson.hello-rs.f00");
+        assert_eq!(gh_result.name.as_str(), "brson.hello-rs.f00");
         assert_eq!(
-            crate_result.url.as_str(),
+            gh_result.url.as_str(),
             "https://github.com/brson/hello-rs/tree/f00"
         );
-        assert_eq!(crate_result.res, Comparison::Regressed);
+        assert_eq!(gh_result.res, Comparison::Regressed);
         assert_eq!(
-            (&crate_result.runs[0]).as_ref().unwrap().res,
+            (&gh_result.runs[0]).as_ref().unwrap().res,
             TestResult::TestPass
         );
         assert_eq!(
-            (&crate_result.runs[1]).as_ref().unwrap().res,
+            (&gh_result.runs[1]).as_ref().unwrap().res,
             TestResult::BuildFail(FailureReason::Unknown)
         );
         assert_eq!(
-            (&crate_result.runs[0]).as_ref().unwrap().log.as_str(),
+            (&gh_result.runs[0]).as_ref().unwrap().log.as_str(),
             "stable/gh/brson.hello-rs"
         );
         assert_eq!(
-            (&crate_result.runs[1]).as_ref().unwrap().log.as_str(),
+            (&gh_result.runs[1]).as_ref().unwrap().log.as_str(),
             "beta/gh/brson.hello-rs"
+        );
+
+        assert_eq!(reg_result.name.as_str(), "syn-1.0.0");
+        assert_eq!(
+            reg_result.url.as_str(),
+            "https://crates.io/crates/syn/1.0.0"
+        );
+        assert_eq!(reg_result.res, Comparison::Regressed);
+        assert_eq!(
+            (&reg_result.runs[0]).as_ref().unwrap().res,
+            TestResult::TestPass
+        );
+        assert_eq!(
+            (&reg_result.runs[1]).as_ref().unwrap().res,
+            TestResult::BuildFail(FailureReason::Unknown)
+        );
+        assert_eq!(
+            (&reg_result.runs[0]).as_ref().unwrap().log.as_str(),
+            "stable/reg/syn-1.0.0"
+        );
+        assert_eq!(
+            (&reg_result.runs[1]).as_ref().unwrap().log.as_str(),
+            "beta/reg/syn-1.0.0"
+        );
+
+        assert_eq!(
+            writer.get("retry-regressed-list.txt", &mime::TEXT_PLAIN_UTF_8),
+            b"brson/hello-rs\nsyn\n",
         );
     }
 }

--- a/templates/report/downloads.html
+++ b/templates/report/downloads.html
@@ -28,16 +28,20 @@
 
     <div class="category">
         <div class="header header-background toggle" data-toggle="#downloads-json">
-            Data exports (JSON)
+            Data exports
         </div>
         <div class="crates" id="downloads-json">
             <div class="crate">
-                <a href="config.json">Experiment configuration</a>
+                <a href="config.json">Experiment configuration (JSON)</a>
                 <span><a href="config.json">Download</a></span>
             </div>
             <div class="crate">
-                <a href="results.json">Results</a>
+                <a href="results.json">Results (JSON)</a>
                 <span><a href="results.json">Download</a></span>
+            </div>
+            <div class="crate">
+                <a href="retry-regressed-list.txt">Regressed crates as list</a>
+                <span><a href="retry-regressed-list.txt">Download</a></span>
             </div>
         </div>
     </div>

--- a/tests/minicrater/blacklist/results.expected.json
+++ b/tests/minicrater/blacklist/results.expected.json
@@ -1,6 +1,9 @@
 {
   "crates": [
     {
+      "krate": {
+        "Local": "build-fail"
+      },
       "name": "build-fail (local)",
       "res": "skipped",
       "runs": [
@@ -10,6 +13,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
     },
     {
+      "krate": {
+        "Local": "build-pass"
+      },
       "name": "build-pass (local)",
       "res": "test-pass",
       "runs": [
@@ -25,6 +31,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     },
     {
+      "krate": {
+        "Local": "test-fail"
+      },
       "name": "test-fail (local)",
       "res": "test-skipped",
       "runs": [

--- a/tests/minicrater/clippy/results.expected.json
+++ b/tests/minicrater/clippy/results.expected.json
@@ -1,6 +1,9 @@
 {
   "crates": [
     {
+      "krate": {
+        "Local": "build-pass"
+      },
       "name": "build-pass (local)",
       "res": "test-pass",
       "runs": [
@@ -16,6 +19,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     },
     {
+      "krate": {
+        "Local": "clippy-warn"
+      },
       "name": "clippy-warn (local)",
       "res": "regressed",
       "runs": [

--- a/tests/minicrater/full/results.expected.json
+++ b/tests/minicrater/full/results.expected.json
@@ -1,6 +1,9 @@
 {
   "crates": [
     {
+      "krate": {
+        "Local": "beta-fixed"
+      },
       "name": "beta-fixed (local)",
       "res": "fixed",
       "runs": [
@@ -16,6 +19,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-fixed"
     },
     {
+      "krate": {
+        "Local": "beta-regression"
+      },
       "name": "beta-regression (local)",
       "res": "regressed",
       "runs": [
@@ -31,6 +37,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
     },
     {
+      "krate": {
+        "Local": "broken-cargotoml"
+      },
       "name": "broken-cargotoml (local)",
       "res": "broken",
       "runs": [
@@ -46,6 +55,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/broken-cargotoml"
     },
     {
+      "krate": {
+        "Local": "build-fail"
+      },
       "name": "build-fail (local)",
       "res": "build-fail",
       "runs": [
@@ -61,6 +73,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
     },
     {
+      "krate": {
+        "Local": "build-pass"
+      },
       "name": "build-pass (local)",
       "res": "test-pass",
       "runs": [
@@ -76,6 +91,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     },
     {
+      "krate": {
+        "Local": "clippy-warn"
+      },
       "name": "clippy-warn (local)",
       "res": "test-pass",
       "runs": [
@@ -91,6 +109,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
     },
     {
+      "krate": {
+        "Local": "memory-hungry"
+      },
       "name": "memory-hungry (local)",
       "res": "skipped",
       "runs": [
@@ -100,6 +121,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
     },
     {
+      "krate": {
+        "Local": "missing-examples"
+      },
       "name": "missing-examples (local)",
       "res": "test-pass",
       "runs": [
@@ -115,6 +139,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/missing-examples"
     },
     {
+      "krate": {
+        "Local": "network-access"
+      },
       "name": "network-access (local)",
       "res": "fixed",
       "runs": [
@@ -130,6 +157,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/network-access"
     },
     {
+      "krate": {
+        "Local": "outdated-lockfile"
+      },
       "name": "outdated-lockfile (local)",
       "res": "test-pass",
       "runs": [
@@ -145,6 +175,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/outdated-lockfile"
     },
     {
+      "krate": {
+        "Local": "test-fail"
+      },
       "name": "test-fail (local)",
       "res": "test-fail",
       "runs": [
@@ -160,6 +193,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
     },
     {
+      "krate": {
+        "Local": "yanked-deps"
+      },
       "name": "yanked-deps (local)",
       "res": "broken",
       "runs": [

--- a/tests/minicrater/ignore-blacklist/results.expected.json
+++ b/tests/minicrater/ignore-blacklist/results.expected.json
@@ -1,6 +1,9 @@
 {
   "crates": [
     {
+      "krate": {
+        "Local": "build-fail"
+      },
       "name": "build-fail (local)",
       "res": "build-fail",
       "runs": [
@@ -16,6 +19,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
     },
     {
+      "krate": {
+        "Local": "build-pass"
+      },
       "name": "build-pass (local)",
       "res": "test-pass",
       "runs": [
@@ -31,6 +37,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     },
     {
+      "krate": {
+        "Local": "test-fail"
+      },
       "name": "test-fail (local)",
       "res": "test-fail",
       "runs": [

--- a/tests/minicrater/missing-repo/results.expected.json
+++ b/tests/minicrater/missing-repo/results.expected.json
@@ -1,6 +1,12 @@
 {
   "crates": [
     {
+      "krate": {
+        "GitHub": {
+          "name": "missing",
+          "org": "ghost"
+        }
+      },
       "name": "ghost.missing",
       "res": "broken",
       "runs": [

--- a/tests/minicrater/resource-exhaustion/results.expected.json
+++ b/tests/minicrater/resource-exhaustion/results.expected.json
@@ -1,6 +1,9 @@
 {
   "crates": [
     {
+      "krate": {
+        "Local": "build-pass"
+      },
       "name": "build-pass (local)",
       "res": "test-pass",
       "runs": [
@@ -16,6 +19,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
     },
     {
+      "krate": {
+        "Local": "memory-hungry"
+      },
       "name": "memory-hungry (local)",
       "res": "spurious-fixed",
       "runs": [

--- a/tests/minicrater/small/results.expected.json
+++ b/tests/minicrater/small/results.expected.json
@@ -1,6 +1,9 @@
 {
   "crates": [
     {
+      "krate": {
+        "Local": "beta-regression"
+      },
       "name": "beta-regression (local)",
       "res": "regressed",
       "runs": [
@@ -16,6 +19,9 @@
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
     },
     {
+      "krate": {
+        "Local": "build-pass"
+      },
       "name": "build-pass (local)",
       "res": "test-pass",
       "runs": [


### PR DESCRIPTION
This is a list that can be passed to crater as "crates" argument. Currently, there is no easy way to obtain such a list from a report.

Just let me know if I should change something!