### PR TITLE
Map TestResult to usize in html report

### DIFF
--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -170,7 +170,6 @@ fn write_report<W: ReportWriter>(
     let mut test_results_to_int = HashMap::new();
     let mut result_colors = Vec::new();
     let mut result_names = Vec::new();
-    let mut index: i32 = -1;
 
     let mut categories = HashMap::new();
     for result in &res.crates {
@@ -191,8 +190,7 @@ fn write_report<W: ReportWriter>(
                 let idx = test_results_to_int.entry(&run.res).or_insert_with(|| {
                     result_colors.push(run.res.color());
                     result_names.push(run.res.name());
-                    index += 1;
-                    index
+                    result_names.len() - 1
                 });
                 runs[pos] = Some(BuildTestResultHTML {
                     res: *idx as usize,

--- a/templates/report/results.html
+++ b/templates/report/results.html
@@ -5,7 +5,7 @@
 {% block extra_head %}
     <style>
         {% for color in result_colors %}
-            .cr-{{ loop.index0 }} {
+            .r{{ loop.index0 }} {
                 {% if color.Single %}
                     background: {{ color.Single }};
                 {% elif color.Striped %}
@@ -15,7 +15,7 @@
         {% endfor %}
 
         {% for name, color in comparison_colors %}
-            .cc-{{ name }} {
+            .c{{ name }} {
                 {% if color.Single %}
                     background: {{ color.Single }};
                 {% elif color.Striped %}
@@ -30,7 +30,7 @@
     {% if categories %}
         {% for name, crates in categories %}
         <div class="category">
-            <div class="header cc-{{ name }} toggle" data-toggle="#crates-{{ name }}">
+            <div class="header c{{ name }} toggle" data-toggle="#crates-{{ name }}">
                 {{ name }} ({{ crates|length }})
             </div>
 
@@ -41,12 +41,12 @@
                         {% for run in crate.runs %}
                             <span class="run">
                                 {% if run %}
-                                    <b class="cr-{{ run.res }}"></b>
+                                    <b class="r{{ run.res }}"></b>
                                     <a href="{{ run.log|safe }}/log.txt">
                                         {{ result_names[run.res] }}
                                     </a>
                                 {% else %}
-                                    <b class="cc-{{ crate.res }}"></b>
+                                    <b class="c{{ crate.res }}"></b>
                                     {{ crate.res }}
                                 {% endif %}
                             </span>

--- a/templates/report/results.html
+++ b/templates/report/results.html
@@ -4,8 +4,8 @@
 
 {% block extra_head %}
     <style>
-        {% for name, color in result_colors %}
-            .cr-{{ name|replace(from=":", to="\:") }} {
+        {% for color in result_colors %}
+            .cr-{{ loop.index0 }} {
                 {% if color.Single %}
                     background: {{ color.Single }};
                 {% elif color.Striped %}


### PR DESCRIPTION
Map `TestResult` to `usize` in report to avoid the presence of special characters in html that make Tera angry. Especially useful for adding new categories in the future.