### PR TITLE
Blacklist some spurious failures

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -118,6 +118,7 @@ treeflection = { skip-tests = true } # flaky test
 update_rate = { skip-tests = true } # flaky tests
 urdf-viz = { skip = true } # flaky build
 vidar = { skip-tests = true } # flaky test
+xtp  = { skip-tests = true } # setrlimit(RLIMIT_CORE): Operation not permitted
 
 [github-repos]
 # "org_name/repo_name" = { option = true }
@@ -129,5 +130,6 @@ vidar = { skip-tests = true } # flaky test
 "kellymclaughlin/rust-quickcheck-example" = { skip-tests = true } # flaky tests
 "otaviopace/minigrep" = { skip-tests = true } # flaky tests
 "wischli/rpaillier" = { skip-tests = true } # flaky tests
+"luc-tielen/fire-emblem-rs" = { skip-tests = true } # setrlimit(RLIMIT_CORE): Operation not permitted
 
 [local-crates]

--- a/config.toml
+++ b/config.toml
@@ -118,7 +118,7 @@ treeflection = { skip-tests = true } # flaky test
 update_rate = { skip-tests = true } # flaky tests
 urdf-viz = { skip = true } # flaky build
 vidar = { skip-tests = true } # flaky test
-xtp  = { skip-tests = true } # setrlimit(RLIMIT_CORE): Operation not permitted
+xtp  = { skip = true } # setrlimit(RLIMIT_CORE): Operation not permitted
 
 [github-repos]
 # "org_name/repo_name" = { option = true }
@@ -130,6 +130,6 @@ xtp  = { skip-tests = true } # setrlimit(RLIMIT_CORE): Operation not permitted
 "kellymclaughlin/rust-quickcheck-example" = { skip-tests = true } # flaky tests
 "otaviopace/minigrep" = { skip-tests = true } # flaky tests
 "wischli/rpaillier" = { skip-tests = true } # flaky tests
-"luc-tielen/fire-emblem-rs" = { skip-tests = true } # setrlimit(RLIMIT_CORE): Operation not permitted
+"luc-tielen/fire-emblem-rs" = { skip = true } # setrlimit(RLIMIT_CORE): Operation not permitted
 
 [local-crates]


### PR DESCRIPTION
I don't know if these qualify as spurious failure, but the following two regressions showed up in a  report recently and (as far as I can tell) do not have anything to do with the actual change:

* https://crater-reports.s3.amazonaws.com/pr-71814/try%235fae8f15a4dcfce640ee800a4d495673524b0a4d/gh/luc-tielen.fire-emblem-rs/log.txt
* https://crater-reports.s3.amazonaws.com/pr-71814/try%235fae8f15a4dcfce640ee800a4d495673524b0a4d/reg/xtp-0.1.0-alpha.4/log.txt

The error in both cases is `sudo: setrlimit(RLIMIT_CORE): Operation not permitted`. Why that is a regression (i.e. why the "reference run" worked and only the changed run failed) I have no idea...