### PR TITLE
Handle skipped crates added after experiment creation

### DIFF
--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -42,6 +42,7 @@ impl ResultColor for TestResult {
             TestResult::TestFail(_) => Color::Single("#65461e"),
             TestResult::TestSkipped | TestResult::TestPass => Color::Single("#62a156"),
             TestResult::Error => Color::Single("#d77026"),
+            TestResult::Skipped => Color::Single("#494b4a"),
         }
     }
 }
@@ -81,6 +82,7 @@ impl ResultName for TestResult {
             TestResult::TestSkipped => "test skipped".into(),
             TestResult::TestPass => "test passed".into(),
             TestResult::Error => "error".into(),
+            TestResult::Skipped => "skipped".into(),
         }
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -391,6 +391,7 @@ fn compare(
             | (TestFail(_), BuildFail(_)) => Comparison::Regressed,
 
             (Error, _) | (_, Error) => Comparison::Error,
+            (Skipped, _) | (_, Skipped) => Comparison::Skipped,
             (BrokenCrate(_), _) | (_, BrokenCrate(_)) => Comparison::Broken,
             (TestFail(_), TestSkipped)
             | (TestPass, TestSkipped)
@@ -686,6 +687,18 @@ mod tests {
                 TestSkipped, Error => Error;
                 TestFail(Unknown), Error => Error;
                 BuildFail(Unknown), Error => Error;
+
+                // Skipped
+                Skipped, Skipped => Skipped;
+                Skipped, TestPass => Skipped;
+                Skipped, TestSkipped => Skipped;
+                Skipped, TestFail(Unknown) => Skipped;
+                Skipped, BuildFail(Unknown) => Skipped;
+                TestPass, Skipped => Skipped;
+                TestSkipped, Skipped => Skipped;
+                TestFail(Unknown), Skipped => Skipped;
+                BuildFail(Unknown), Skipped => Skipped;
+
 
                 // Broken
                 BrokenCrate(BrokenReason::Unknown), TestPass => Broken;

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -200,6 +200,7 @@ test_result_enum!(pub enum TestResult {
     without_reason {
         TestSkipped => "test-skipped",
         TestPass => "test-pass",
+        Skipped => "skipped",
         Error => "error",
     }
 });

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -260,6 +260,16 @@ pub(super) fn build_graph(ex: &Experiment, crates: &[Crate], config: &Config) ->
 
     for krate in crates {
         if !ex.ignore_blacklist && config.should_skip(krate) {
+            for tc in &ex.toolchains {
+                let id = graph.add_task(
+                    Task {
+                        krate: krate.clone(),
+                        step: TaskStep::Skip { tc: tc.clone() },
+                    },
+                    &[],
+                );
+                graph.add_crate(&[id]);
+            }
             continue;
         }
 


### PR DESCRIPTION
Before this PR, if a new crate was added to the blacklist after an experiment was created a deadlock occured:

1. During experiment creation, the crate is added to the list of crates test during such experiment.
2. The crate is blacklisted, and the server is restarted to apply the blacklist change.
3. The experiment starts running.
4. An agent asks for crates to test during an experiment, and receives the blacklisted crate.
5. The agent ignores the blacklisted crate as it's blacklisted, and replies "I'm done" to the server without actually recording any result for the skipped crate.
6. The server readds the blacklisted crate to the queue for that agent, as it thinks that crate has to be tested and the agent didn't do it.

This PR fixes the deadlock by adding a new "Skip" task to the graph, which sends a "skipped" result for blacklisted crates to the server instead of silently ignoring them.