### PR TITLE
Fix experiment page

### DIFF
--- a/src/report/display.rs
+++ b/src/report/display.rs
@@ -1,0 +1,87 @@
+use crate::prelude::*;
+use crate::report::Comparison;
+use crate::results::{BrokenReason, FailureReason, TestResult};
+
+pub trait ResultName {
+    fn name(&self) -> String;
+}
+
+impl ResultName for FailureReason {
+    fn name(&self) -> String {
+        match self {
+            FailureReason::Unknown => "failed".into(),
+            FailureReason::Timeout => "timed out".into(),
+            FailureReason::OOM => "OOM".into(),
+            FailureReason::ICE => "ICE".into(),
+            FailureReason::CompilerError(_) => "compiler error".into(),
+            FailureReason::DependsOn(_) => "faulty deps".into(),
+        }
+    }
+}
+
+impl ResultName for BrokenReason {
+    fn name(&self) -> String {
+        match self {
+            BrokenReason::Unknown => "broken crate".into(),
+            BrokenReason::CargoToml => "broken Cargo.toml".into(),
+            BrokenReason::Yanked => "deps yanked".into(),
+            BrokenReason::MissingGitRepository => "missing repo".into(),
+        }
+    }
+}
+
+impl ResultName for TestResult {
+    fn name(&self) -> String {
+        match self {
+            TestResult::BrokenCrate(reason) => reason.name(),
+            TestResult::BuildFail(reason) => format!("build {}", reason.name()),
+            TestResult::TestFail(reason) => format!("test {}", reason.name()),
+            TestResult::TestSkipped => "test skipped".into(),
+            TestResult::TestPass => "test passed".into(),
+            TestResult::Error => "error".into(),
+            TestResult::Skipped => "skipped".into(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub enum Color {
+    Single(&'static str),
+    Striped(&'static str, &'static str),
+}
+
+pub trait ResultColor {
+    fn color(&self) -> Color;
+}
+
+impl ResultColor for Comparison {
+    fn color(&self) -> Color {
+        match self {
+            Comparison::Regressed => Color::Single("#db3026"),
+            Comparison::Fixed => Color::Single("#5630db"),
+            Comparison::Skipped => Color::Striped("#494b4a", "#555555"),
+            Comparison::Unknown => Color::Single("#494b4a"),
+            Comparison::SameBuildFail => Color::Single("#65461e"),
+            Comparison::SameTestFail => Color::Single("#788843"),
+            Comparison::SameTestSkipped => Color::Striped("#72a156", "#80b65f"),
+            Comparison::SameTestPass => Color::Single("#72a156"),
+            Comparison::Error => Color::Single("#d77026"),
+            Comparison::Broken => Color::Single("#44176e"),
+            Comparison::SpuriousRegressed => Color::Striped("#db3026", "#d5433b"),
+            Comparison::SpuriousFixed => Color::Striped("#5630db", "#5d3dcf"),
+        }
+    }
+}
+
+impl ResultColor for TestResult {
+    fn color(&self) -> Color {
+        match self {
+            TestResult::BrokenCrate(_) => Color::Single("#44176e"),
+            TestResult::BuildFail(_) => Color::Single("#db3026"),
+            TestResult::TestFail(_) => Color::Single("#65461e"),
+            TestResult::TestSkipped | TestResult::TestPass => Color::Single("#62a156"),
+            TestResult::Error => Color::Single("#d77026"),
+            TestResult::Skipped => Color::Single("#494b4a"),
+        }
+    }
+}

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -1,93 +1,11 @@
 use crate::assets;
 use crate::experiments::Experiment;
 use crate::prelude::*;
-use crate::report::{archives::Archive, Comparison, ReportWriter, TestResults};
-use crate::results::{BrokenReason, EncodingType, FailureReason, TestResult};
+use crate::report::{
+    archives::Archive, Color, Comparison, ReportWriter, ResultColor, ResultName, TestResults,
+};
+use crate::results::EncodingType;
 use std::collections::HashMap;
-
-#[derive(Serialize)]
-enum Color {
-    Single(&'static str),
-    Striped(&'static str, &'static str),
-}
-
-trait ResultColor {
-    fn color(&self) -> Color;
-}
-
-impl ResultColor for Comparison {
-    fn color(&self) -> Color {
-        match self {
-            Comparison::Regressed => Color::Single("#db3026"),
-            Comparison::Fixed => Color::Single("#5630db"),
-            Comparison::Skipped => Color::Striped("#494b4a", "#555555"),
-            Comparison::Unknown => Color::Single("#494b4a"),
-            Comparison::SameBuildFail => Color::Single("#65461e"),
-            Comparison::SameTestFail => Color::Single("#788843"),
-            Comparison::SameTestSkipped => Color::Striped("#72a156", "#80b65f"),
-            Comparison::SameTestPass => Color::Single("#72a156"),
-            Comparison::Error => Color::Single("#d77026"),
-            Comparison::Broken => Color::Single("#44176e"),
-            Comparison::SpuriousRegressed => Color::Striped("#db3026", "#d5433b"),
-            Comparison::SpuriousFixed => Color::Striped("#5630db", "#5d3dcf"),
-        }
-    }
-}
-
-impl ResultColor for TestResult {
-    fn color(&self) -> Color {
-        match self {
-            TestResult::BrokenCrate(_) => Color::Single("#44176e"),
-            TestResult::BuildFail(_) => Color::Single("#db3026"),
-            TestResult::TestFail(_) => Color::Single("#65461e"),
-            TestResult::TestSkipped | TestResult::TestPass => Color::Single("#62a156"),
-            TestResult::Error => Color::Single("#d77026"),
-            TestResult::Skipped => Color::Single("#494b4a"),
-        }
-    }
-}
-
-trait ResultName {
-    fn name(&self) -> String;
-}
-
-impl ResultName for FailureReason {
-    fn name(&self) -> String {
-        match self {
-            FailureReason::Unknown => "failed".into(),
-            FailureReason::Timeout => "timed out".into(),
-            FailureReason::OOM => "OOM".into(),
-            FailureReason::ICE => "ICE".into(),
-            FailureReason::CompilerError(_) => "compiler error".into(),
-            FailureReason::DependsOn(_) => "faulty deps".into(),
-        }
-    }
-}
-
-impl ResultName for BrokenReason {
-    fn name(&self) -> String {
-        match self {
-            BrokenReason::Unknown => "broken crate".into(),
-            BrokenReason::CargoToml => "broken Cargo.toml".into(),
-            BrokenReason::Yanked => "deps yanked".into(),
-            BrokenReason::MissingGitRepository => "missing repo".into(),
-        }
-    }
-}
-
-impl ResultName for TestResult {
-    fn name(&self) -> String {
-        match self {
-            TestResult::BrokenCrate(reason) => reason.name(),
-            TestResult::BuildFail(reason) => format!("build {}", reason.name()),
-            TestResult::TestFail(reason) => format!("test {}", reason.name()),
-            TestResult::TestSkipped => "test skipped".into(),
-            TestResult::TestPass => "test passed".into(),
-            TestResult::Error => "error".into(),
-            TestResult::Skipped => "skipped".into(),
-        }
-    }
-}
 
 #[derive(Serialize)]
 struct NavbarItem {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::crates::Crate;
 use crate::experiments::Experiment;
 use crate::prelude::*;
-use crate::results::{EncodedLog, EncodingType, ReadResults, TestResult};
+use crate::results::{EncodedLog, EncodingType, FailureReason, ReadResults, TestResult};
 use crate::toolchain::Toolchain;
 use crate::utils;
 use mime::{self, Mime};
@@ -19,9 +19,11 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 mod archives;
+mod display;
 mod html;
 mod s3;
 
+pub use self::display::{Color, ResultColor, ResultName};
 pub use self::s3::{get_client_for_bucket, S3Prefix, S3Writer};
 
 pub(crate) const REPORT_ENCODE_SET: AsciiSet = percent_encoding::CONTROLS
@@ -361,7 +363,6 @@ fn compare(
     r1: Option<&TestResult>,
     r2: Option<&TestResult>,
 ) -> Comparison {
-    use crate::results::FailureReason;
     use crate::results::TestResult::*;
 
     match (r1, r2) {


### PR DESCRIPTION
This fixes the extremely long list of results in the experiment page by grouping `CompilerError` and `DependsOn` under a single counter.

`ResultName` and `ResultColor` are also moved into a separate file. This is done because those traits are not used only by `html` module anymore (especially if we consider future updates on markdown report). They could have been moved to `mod.rs` but I feel like this way it's cleaner and we avoid having too many things on that file.