### PR TITLE
Tests for HTML reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "backtrace"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +326,7 @@ dependencies = [
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -792,7 +798,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -810,7 +816,7 @@ dependencies = [
  "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1025,9 +1031,10 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.0.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1939,7 +1946,7 @@ name = "rust_team_data"
 version = "1.0.0"
 source = "git+https://github.com/rust-lang/team#8d8902d7d4d3542f131f9dc7e7fde83732d92e88"
 dependencies = [
- "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3070,6 +3077,7 @@ dependencies = [
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum assert_cmd 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d5db841dcfb4f172f34ec968f71c4a88e69f5421fb33e0daac6bfe4372317526"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
@@ -3170,7 +3178,7 @@ dependencies = [
 "checksum hyper-tls 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
-"checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
+"checksum indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 "checksum input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b822cc844905551931d6f81608ed5f50a79c1078a4e2b4d42dbc7c1eedfbf"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ remove_dir_all = "0.5.2"
 ctrlc = "3.1.3"
 prometheus = "0.7.0"
 cargo_metadata = "0.9.1"
+indexmap = "1.4.0"
 
 [dev-dependencies]
 assert_cmd = "0.10.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -243,6 +243,8 @@ pub enum Crater {
         dest: Dest,
         #[structopt(name = "force", long = "force")]
         force: bool,
+        #[structopt(name = "output-templates", long = "output-templates")]
+        output_templates: bool,
     },
 
     #[structopt(name = "publish-report", about = "publish the experiment report to S3")]
@@ -258,6 +260,8 @@ pub enum Crater {
         s3_prefix: report::S3Prefix,
         #[structopt(name = "force", long = "force")]
         force: bool,
+        #[structopt(name = "output-templates", long = "output-templates")]
+        output_templates: bool,
     },
 
     #[structopt(name = "server")]
@@ -503,6 +507,7 @@ impl Crater {
                 ref ex,
                 ref dest,
                 force,
+                output_templates,
             } => {
                 let config = Config::load()?;
                 let db = Database::open()?;
@@ -527,6 +532,7 @@ impl Crater {
                         &experiment.get_crates(&db)?,
                         &report::FileWriter::create(dest.0.clone())?,
                         &config,
+                        output_templates,
                     );
 
                     if let Err(err) = res {
@@ -543,6 +549,7 @@ impl Crater {
                 ref ex,
                 ref s3_prefix,
                 force,
+                output_templates,
             } => {
                 let config = Config::load()?;
                 let db = Database::open()?;
@@ -569,6 +576,7 @@ impl Crater {
                         &experiment.get_crates(&db)?,
                         &report::S3Writer::create(client, s3_prefix.clone())?,
                         &config,
+                        output_templates,
                     );
 
                     if let Err(err) = res {

--- a/src/report/archives.rs
+++ b/src/report/archives.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::report::{compare, ReportWriter};
 use crate::results::{EncodedLog, EncodingType, ReadResults};
 use flate2::{write::GzEncoder, Compression};
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use tar::{Builder as TarBuilder, Header as TarHeader};
 
 #[derive(Serialize)]
@@ -23,7 +23,7 @@ pub fn write_logs_archives<DB: ReadResults, W: ReportWriter>(
 ) -> Fallible<Vec<Archive>> {
     let mut archives = Vec::new();
     let mut all = TarBuilder::new(GzEncoder::new(Vec::new(), Compression::default()));
-    let mut by_comparison = HashMap::new();
+    let mut by_comparison = IndexMap::new();
 
     for krate in crates {
         if config.should_skip(krate) {
@@ -86,7 +86,7 @@ pub fn write_logs_archives<DB: ReadResults, W: ReportWriter>(
         path: "logs-archives/all.tar.gz".to_string(),
     });
 
-    for (comparison, archive) in by_comparison.drain() {
+    for (comparison, archive) in by_comparison.drain(..) {
         let data = archive.into_inner()?.finish()?;
         dest.write_bytes(
             &format!("logs-archives/{}.tar.gz", comparison),

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -6,7 +6,7 @@ use crate::report::{
     ResultColor, ResultName, TestResults,
 };
 use crate::results::{EncodingType, FailureReason, TestResult};
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 #[derive(Serialize)]
 struct NavbarItem {
@@ -27,11 +27,11 @@ enum ReportCratesHTML {
     Plain(Vec<CrateResultHTML>),
     Tree {
         count: u32,
-        tree: HashMap<String, Vec<CrateResultHTML>>,
+        tree: IndexMap<String, Vec<CrateResultHTML>>,
     },
     RootResults {
         count: u32,
-        results: HashMap<String, Vec<CrateResultHTML>>,
+        results: IndexMap<String, Vec<CrateResultHTML>>,
     },
 }
 
@@ -62,10 +62,10 @@ struct ResultsContext<'a> {
     ex: &'a Experiment,
     nav: Vec<NavbarItem>,
     categories: Vec<(Comparison, ReportCratesHTML)>,
-    info: HashMap<Comparison, u32>,
+    info: IndexMap<Comparison, u32>,
     full: bool,
     crates_count: usize,
-    comparison_colors: HashMap<Comparison, Color>,
+    comparison_colors: IndexMap<Comparison, Color>,
     result_colors: Vec<Color>,
     result_names: Vec<String>,
 }
@@ -103,8 +103,8 @@ fn write_report<W: ReportWriter>(
     dest: &W,
     output_templates: bool,
 ) -> Fallible<()> {
-    let mut comparison_colors = HashMap::new();
-    let mut test_results_to_int = HashMap::new();
+    let mut comparison_colors = IndexMap::new();
+    let mut test_results_to_int = IndexMap::new();
     let mut result_colors = Vec::new();
     let mut result_names = Vec::new();
 
@@ -165,7 +165,7 @@ fn write_report<W: ReportWriter>(
                                     .collect::<Vec<_>>(),
                             )
                         })
-                        .collect::<HashMap<_, _>>();
+                        .collect::<IndexMap<_, _>>();
                     let results = results
                         .into_iter()
                         .map(|(res, krates)| {
@@ -182,7 +182,7 @@ fn write_report<W: ReportWriter>(
                                     .collect::<Vec<_>>(),
                             )
                         })
-                        .collect::<HashMap<_, _>>();
+                        .collect::<IndexMap<_, _>>();
 
                     vec![
                         (

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -275,6 +275,7 @@ pub fn gen<DB: ReadResults, W: ReportWriter + Display>(
     crates: &[Crate],
     dest: &W,
     config: &Config,
+    output_templates: bool,
 ) -> Fallible<TestResults> {
     let raw = generate_report(db, config, ex, crates)?;
 
@@ -300,7 +301,14 @@ pub fn gen<DB: ReadResults, W: ReportWriter + Display>(
     info!("writing archives");
     let available_archives = archives::write_logs_archives(db, ex, crates, dest, config)?;
     info!("writing html files");
-    html::write_html_report(ex, crates.len(), &res, available_archives, dest)?;
+    html::write_html_report(
+        ex,
+        crates.len(),
+        &res,
+        available_archives,
+        dest,
+        output_templates,
+    )?;
     info!("writing logs");
     write_logs(db, ex, crates, dest, config)?;
 
@@ -871,7 +879,7 @@ mod tests {
         );
 
         let writer = DummyWriter::default();
-        gen(&db, &ex, &[gh, reg], &writer, &config).unwrap();
+        gen(&db, &ex, &[gh, reg], &writer, &config, false).unwrap();
 
         assert_eq!(
             writer.get("config.json", &mime::APPLICATION_JSON),

--- a/src/server/reports.rs
+++ b/src/server/reports.rs
@@ -24,7 +24,7 @@ fn generate_report(data: &Data, ex: &Experiment, results: &DatabaseDB) -> Fallib
     let writer = report::S3Writer::create(Box::new(client), dest.parse()?)?;
 
     let crates = ex.get_crates(&data.db)?;
-    let res = report::gen(results, &ex, &crates, &writer, &data.config)?;
+    let res = report::gen(results, &ex, &crates, &writer, &data.config, false)?;
 
     //remove metrics about completed experiments
     data.metrics.on_complete_experiment(&ex.name)?;

--- a/tests/minicrater/blacklist/downloads.html.context.expected.json
+++ b/tests/minicrater/blacklist/downloads.html.context.expected.json
@@ -1,0 +1,34 @@
+{
+  "available_archives": [
+    {
+      "name": "All the crates",
+      "path": "logs-archives/all.tar.gz"
+    },
+    {
+      "name": "test-pass crates",
+      "path": "logs-archives/test-pass.tar.gz"
+    },
+    {
+      "name": "test-skipped crates",
+      "path": "logs-archives/test-skipped.tar.gz"
+    }
+  ],
+  "crates_count": 3,
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": true,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ]
+}

--- a/tests/minicrater/blacklist/full.html.context.expected.json
+++ b/tests/minicrater/blacklist/full.html.context.expected.json
@@ -1,0 +1,117 @@
+{
+  "categories": [
+    [
+      "skipped",
+      {
+        "Plain": [
+          {
+            "name": "build-fail (local)",
+            "res": "skipped",
+            "runs": [
+              null,
+              null
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
+          }
+        ]
+      }
+    ],
+    [
+      "test-pass",
+      {
+        "Plain": [
+          {
+            "name": "build-pass (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/build-pass",
+                "res": 0
+              },
+              {
+                "log": "beta/local/build-pass",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
+          }
+        ]
+      }
+    ],
+    [
+      "test-skipped",
+      {
+        "Plain": [
+          {
+            "name": "test-fail (local)",
+            "res": "test-skipped",
+            "runs": [
+              {
+                "log": "stable/local/test-fail",
+                "res": 1
+              },
+              {
+                "log": "beta/local/test-fail",
+                "res": 1
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
+          }
+        ]
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "skipped": {
+      "Striped": [
+        "#494b4a",
+        "#555555"
+      ]
+    },
+    "test-pass": {
+      "Single": "#72a156"
+    },
+    "test-skipped": {
+      "Striped": [
+        "#72a156",
+        "#80b65f"
+      ]
+    }
+  },
+  "crates_count": 3,
+  "full": true,
+  "info": {
+    "skipped": 1,
+    "test-pass": 1,
+    "test-skipped": 1
+  },
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": true,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#62a156"
+    }
+  ],
+  "result_names": [
+    "test passed",
+    "test skipped"
+  ]
+}

--- a/tests/minicrater/blacklist/index.html.context.expected.json
+++ b/tests/minicrater/blacklist/index.html.context.expected.json
@@ -1,0 +1,30 @@
+{
+  "categories": [],
+  "comparison_colors": {},
+  "crates_count": 3,
+  "full": false,
+  "info": {
+    "skipped": 1,
+    "test-pass": 1,
+    "test-skipped": 1
+  },
+  "nav": [
+    {
+      "active": true,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [],
+  "result_names": []
+}

--- a/tests/minicrater/clippy/downloads.html.context.expected.json
+++ b/tests/minicrater/clippy/downloads.html.context.expected.json
@@ -1,0 +1,34 @@
+{
+  "available_archives": [
+    {
+      "name": "All the crates",
+      "path": "logs-archives/all.tar.gz"
+    },
+    {
+      "name": "test-pass crates",
+      "path": "logs-archives/test-pass.tar.gz"
+    },
+    {
+      "name": "regressed crates",
+      "path": "logs-archives/regressed.tar.gz"
+    }
+  ],
+  "crates_count": 2,
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": true,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ]
+}

--- a/tests/minicrater/clippy/full.html.context.expected.json
+++ b/tests/minicrater/clippy/full.html.context.expected.json
@@ -1,0 +1,105 @@
+{
+  "categories": [
+    [
+      "test-pass",
+      {
+        "Plain": [
+          {
+            "name": "build-pass (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/build-pass",
+                "res": 0
+              },
+              {
+                "log": "stable%2Brustflags=-Dclippy::all/local/build-pass",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
+          }
+        ]
+      }
+    ],
+    [
+      "regressed",
+      {
+        "Tree": {
+          "count": 0,
+          "tree": {}
+        }
+      }
+    ],
+    [
+      "regressed",
+      {
+        "RootResults": {
+          "count": 1,
+          "results": {
+            "build-fail:compiler-error(clippy::print_with_newline)": [
+              {
+                "name": "clippy-warn (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/clippy-warn",
+                    "res": 0
+                  },
+                  {
+                    "log": "stable%2Brustflags=-Dclippy::all/local/clippy-warn",
+                    "res": 1
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "regressed": {
+      "Single": "#db3026"
+    },
+    "test-pass": {
+      "Single": "#72a156"
+    }
+  },
+  "crates_count": 2,
+  "full": true,
+  "info": {
+    "regressed": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": true,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
+    }
+  ],
+  "result_names": [
+    "test passed",
+    "build compiler error"
+  ]
+}

--- a/tests/minicrater/clippy/index.html.context.expected.json
+++ b/tests/minicrater/clippy/index.html.context.expected.json
@@ -1,0 +1,80 @@
+{
+  "categories": [
+    [
+      "regressed",
+      {
+        "Tree": {
+          "count": 0,
+          "tree": {}
+        }
+      }
+    ],
+    [
+      "regressed",
+      {
+        "RootResults": {
+          "count": 1,
+          "results": {
+            "build-fail:compiler-error(clippy::print_with_newline)": [
+              {
+                "name": "clippy-warn (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/clippy-warn",
+                    "res": 0
+                  },
+                  {
+                    "log": "stable%2Brustflags=-Dclippy::all/local/clippy-warn",
+                    "res": 1
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "regressed": {
+      "Single": "#db3026"
+    }
+  },
+  "crates_count": 2,
+  "full": false,
+  "info": {
+    "regressed": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": true,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
+    }
+  ],
+  "result_names": [
+    "test passed",
+    "build compiler error"
+  ]
+}

--- a/tests/minicrater/full/downloads.html.context.expected.json
+++ b/tests/minicrater/full/downloads.html.context.expected.json
@@ -1,0 +1,50 @@
+{
+  "available_archives": [
+    {
+      "name": "All the crates",
+      "path": "logs-archives/all.tar.gz"
+    },
+    {
+      "name": "regressed crates",
+      "path": "logs-archives/regressed.tar.gz"
+    },
+    {
+      "name": "fixed crates",
+      "path": "logs-archives/fixed.tar.gz"
+    },
+    {
+      "name": "broken crates",
+      "path": "logs-archives/broken.tar.gz"
+    },
+    {
+      "name": "build-fail crates",
+      "path": "logs-archives/build-fail.tar.gz"
+    },
+    {
+      "name": "test-pass crates",
+      "path": "logs-archives/test-pass.tar.gz"
+    },
+    {
+      "name": "test-fail crates",
+      "path": "logs-archives/test-fail.tar.gz"
+    }
+  ],
+  "crates_count": 16,
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": true,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ]
+}

--- a/tests/minicrater/full/full.html.context.expected.json
+++ b/tests/minicrater/full/full.html.context.expected.json
@@ -1,0 +1,437 @@
+{
+  "categories": [
+    [
+      "regressed",
+      {
+        "Tree": {
+          "count": 1,
+          "tree": {
+            "rust-lang/crater/f190933e896443e285e3bb6962fb87d7439b8d65": [
+              {
+                "name": "beta-faulty-deps (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/beta-faulty-deps",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/beta-faulty-deps",
+                    "res": 1
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    [
+      "regressed",
+      {
+        "RootResults": {
+          "count": 4,
+          "results": {
+            "build ICE": [
+              {
+                "name": "ice-regression (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/ice-regression",
+                    "res": 4
+                  },
+                  {
+                    "log": "beta/local/ice-regression",
+                    "res": 5
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/ice-regression"
+              }
+            ],
+            "build failed (unknown)": [
+              {
+                "name": "beta-regression (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/beta-regression",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/beta-regression",
+                    "res": 2
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
+              }
+            ],
+            "build-fail:compiler-error(E0013)": [
+              {
+                "name": "error-code (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/error-code",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/error-code",
+                    "res": 3
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
+              }
+            ],
+            "build-fail:compiler-error(E0015)": [
+              {
+                "name": "error-code (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/error-code",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/error-code",
+                    "res": 3
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    [
+      "fixed",
+      {
+        "Tree": {
+          "count": 0,
+          "tree": {}
+        }
+      }
+    ],
+    [
+      "fixed",
+      {
+        "RootResults": {
+          "count": 1,
+          "results": {
+            "build failed (unknown)": [
+              {
+                "name": "beta-fixed (local)",
+                "res": "fixed",
+                "runs": [
+                  {
+                    "log": "stable/local/beta-fixed",
+                    "res": 2
+                  },
+                  {
+                    "log": "beta/local/beta-fixed",
+                    "res": 0
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-fixed"
+              },
+              {
+                "name": "network-access (local)",
+                "res": "fixed",
+                "runs": [
+                  {
+                    "log": "stable/local/network-access",
+                    "res": 2
+                  },
+                  {
+                    "log": "beta/local/network-access",
+                    "res": 6
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/network-access"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    [
+      "broken",
+      {
+        "Plain": [
+          {
+            "name": "broken-cargotoml (local)",
+            "res": "broken",
+            "runs": [
+              {
+                "log": "stable/local/broken-cargotoml",
+                "res": 7
+              },
+              {
+                "log": "beta/local/broken-cargotoml",
+                "res": 7
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/broken-cargotoml"
+          },
+          {
+            "name": "yanked-deps (local)",
+            "res": "broken",
+            "runs": [
+              {
+                "log": "stable/local/yanked-deps",
+                "res": 8
+              },
+              {
+                "log": "beta/local/yanked-deps",
+                "res": 8
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/yanked-deps"
+          }
+        ]
+      }
+    ],
+    [
+      "build-fail",
+      {
+        "Plain": [
+          {
+            "name": "build-fail (local)",
+            "res": "build-fail",
+            "runs": [
+              {
+                "log": "stable/local/build-fail",
+                "res": 2
+              },
+              {
+                "log": "beta/local/build-fail",
+                "res": 2
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
+          },
+          {
+            "name": "faulty-deps (local)",
+            "res": "build-fail",
+            "runs": [
+              {
+                "log": "stable/local/faulty-deps",
+                "res": 9
+              },
+              {
+                "log": "beta/local/faulty-deps",
+                "res": 9
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/faulty-deps"
+          }
+        ]
+      }
+    ],
+    [
+      "test-pass",
+      {
+        "Plain": [
+          {
+            "name": "build-pass (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/build-pass",
+                "res": 0
+              },
+              {
+                "log": "beta/local/build-pass",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
+          },
+          {
+            "name": "clippy-warn (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/clippy-warn",
+                "res": 0
+              },
+              {
+                "log": "beta/local/clippy-warn",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
+          },
+          {
+            "name": "missing-examples (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/missing-examples",
+                "res": 0
+              },
+              {
+                "log": "beta/local/missing-examples",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/missing-examples"
+          },
+          {
+            "name": "outdated-lockfile (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/outdated-lockfile",
+                "res": 0
+              },
+              {
+                "log": "beta/local/outdated-lockfile",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/outdated-lockfile"
+          }
+        ]
+      }
+    ],
+    [
+      "skipped",
+      {
+        "Plain": [
+          {
+            "name": "memory-hungry (local)",
+            "res": "skipped",
+            "runs": [
+              null,
+              null
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
+          }
+        ]
+      }
+    ],
+    [
+      "test-fail",
+      {
+        "Plain": [
+          {
+            "name": "test-fail (local)",
+            "res": "test-fail",
+            "runs": [
+              {
+                "log": "stable/local/test-fail",
+                "res": 6
+              },
+              {
+                "log": "beta/local/test-fail",
+                "res": 6
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
+          }
+        ]
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "broken": {
+      "Single": "#44176e"
+    },
+    "build-fail": {
+      "Single": "#65461e"
+    },
+    "fixed": {
+      "Single": "#5630db"
+    },
+    "regressed": {
+      "Single": "#db3026"
+    },
+    "skipped": {
+      "Striped": [
+        "#494b4a",
+        "#555555"
+      ]
+    },
+    "test-fail": {
+      "Single": "#788843"
+    },
+    "test-pass": {
+      "Single": "#72a156"
+    }
+  },
+  "crates_count": 16,
+  "full": true,
+  "info": {
+    "broken": 2,
+    "build-fail": 2,
+    "fixed": 2,
+    "regressed": 4,
+    "skipped": 1,
+    "test-fail": 1,
+    "test-pass": 4
+  },
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": true,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#65461e"
+    },
+    {
+      "Single": "#44176e"
+    },
+    {
+      "Single": "#44176e"
+    },
+    {
+      "Single": "#db3026"
+    }
+  ],
+  "result_names": [
+    "test passed",
+    "build faulty deps",
+    "build failed (unknown)",
+    "build compiler error",
+    "build compiler error",
+    "build ICE",
+    "test failed (unknown)",
+    "broken Cargo.toml",
+    "deps yanked",
+    "build faulty deps"
+  ]
+}

--- a/tests/minicrater/full/index.html.context.expected.json
+++ b/tests/minicrater/full/index.html.context.expected.json
@@ -1,0 +1,228 @@
+{
+  "categories": [
+    [
+      "regressed",
+      {
+        "Tree": {
+          "count": 1,
+          "tree": {
+            "rust-lang/crater/f190933e896443e285e3bb6962fb87d7439b8d65": [
+              {
+                "name": "beta-faulty-deps (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/beta-faulty-deps",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/beta-faulty-deps",
+                    "res": 1
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    [
+      "regressed",
+      {
+        "RootResults": {
+          "count": 4,
+          "results": {
+            "build ICE": [
+              {
+                "name": "ice-regression (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/ice-regression",
+                    "res": 4
+                  },
+                  {
+                    "log": "beta/local/ice-regression",
+                    "res": 5
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/ice-regression"
+              }
+            ],
+            "build failed (unknown)": [
+              {
+                "name": "beta-regression (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/beta-regression",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/beta-regression",
+                    "res": 2
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
+              }
+            ],
+            "build-fail:compiler-error(E0013)": [
+              {
+                "name": "error-code (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/error-code",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/error-code",
+                    "res": 3
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
+              }
+            ],
+            "build-fail:compiler-error(E0015)": [
+              {
+                "name": "error-code (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/error-code",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/error-code",
+                    "res": 3
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    [
+      "fixed",
+      {
+        "Tree": {
+          "count": 0,
+          "tree": {}
+        }
+      }
+    ],
+    [
+      "fixed",
+      {
+        "RootResults": {
+          "count": 1,
+          "results": {
+            "build failed (unknown)": [
+              {
+                "name": "beta-fixed (local)",
+                "res": "fixed",
+                "runs": [
+                  {
+                    "log": "stable/local/beta-fixed",
+                    "res": 2
+                  },
+                  {
+                    "log": "beta/local/beta-fixed",
+                    "res": 0
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-fixed"
+              },
+              {
+                "name": "network-access (local)",
+                "res": "fixed",
+                "runs": [
+                  {
+                    "log": "stable/local/network-access",
+                    "res": 2
+                  },
+                  {
+                    "log": "beta/local/network-access",
+                    "res": 6
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/network-access"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "fixed": {
+      "Single": "#5630db"
+    },
+    "regressed": {
+      "Single": "#db3026"
+    }
+  },
+  "crates_count": 16,
+  "full": false,
+  "info": {
+    "broken": 2,
+    "build-fail": 2,
+    "fixed": 2,
+    "regressed": 4,
+    "skipped": 1,
+    "test-fail": 1,
+    "test-pass": 4
+  },
+  "nav": [
+    {
+      "active": true,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#65461e"
+    }
+  ],
+  "result_names": [
+    "test passed",
+    "build faulty deps",
+    "build failed (unknown)",
+    "build compiler error",
+    "build compiler error",
+    "build ICE",
+    "test failed (unknown)"
+  ]
+}

--- a/tests/minicrater/ignore-blacklist/downloads.html.context.expected.json
+++ b/tests/minicrater/ignore-blacklist/downloads.html.context.expected.json
@@ -1,0 +1,34 @@
+{
+  "available_archives": [
+    {
+      "name": "All the crates",
+      "path": "logs-archives/all.tar.gz"
+    },
+    {
+      "name": "test-pass crates",
+      "path": "logs-archives/test-pass.tar.gz"
+    },
+    {
+      "name": "test-fail crates",
+      "path": "logs-archives/test-fail.tar.gz"
+    }
+  ],
+  "crates_count": 3,
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": true,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ]
+}

--- a/tests/minicrater/ignore-blacklist/full.html.context.expected.json
+++ b/tests/minicrater/ignore-blacklist/full.html.context.expected.json
@@ -1,0 +1,121 @@
+{
+  "categories": [
+    [
+      "build-fail",
+      {
+        "Plain": [
+          {
+            "name": "build-fail (local)",
+            "res": "build-fail",
+            "runs": [
+              {
+                "log": "stable/local/build-fail",
+                "res": 0
+              },
+              {
+                "log": "beta/local/build-fail",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
+          }
+        ]
+      }
+    ],
+    [
+      "test-pass",
+      {
+        "Plain": [
+          {
+            "name": "build-pass (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/build-pass",
+                "res": 1
+              },
+              {
+                "log": "beta/local/build-pass",
+                "res": 1
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
+          }
+        ]
+      }
+    ],
+    [
+      "test-fail",
+      {
+        "Plain": [
+          {
+            "name": "test-fail (local)",
+            "res": "test-fail",
+            "runs": [
+              {
+                "log": "stable/local/test-fail",
+                "res": 2
+              },
+              {
+                "log": "beta/local/test-fail",
+                "res": 2
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
+          }
+        ]
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "build-fail": {
+      "Single": "#65461e"
+    },
+    "test-fail": {
+      "Single": "#788843"
+    },
+    "test-pass": {
+      "Single": "#72a156"
+    }
+  },
+  "crates_count": 3,
+  "full": true,
+  "info": {
+    "build-fail": 1,
+    "test-fail": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": true,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#65461e"
+    }
+  ],
+  "result_names": [
+    "build failed (unknown)",
+    "test passed",
+    "test failed (unknown)"
+  ]
+}

--- a/tests/minicrater/ignore-blacklist/index.html.context.expected.json
+++ b/tests/minicrater/ignore-blacklist/index.html.context.expected.json
@@ -1,0 +1,30 @@
+{
+  "categories": [],
+  "comparison_colors": {},
+  "crates_count": 3,
+  "full": false,
+  "info": {
+    "build-fail": 1,
+    "test-fail": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": true,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [],
+  "result_names": []
+}

--- a/tests/minicrater/missing-repo/downloads.html.context.expected.json
+++ b/tests/minicrater/missing-repo/downloads.html.context.expected.json
@@ -1,0 +1,30 @@
+{
+  "available_archives": [
+    {
+      "name": "All the crates",
+      "path": "logs-archives/all.tar.gz"
+    },
+    {
+      "name": "broken crates",
+      "path": "logs-archives/broken.tar.gz"
+    }
+  ],
+  "crates_count": 1,
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": true,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ]
+}

--- a/tests/minicrater/missing-repo/full.html.context.expected.json
+++ b/tests/minicrater/missing-repo/full.html.context.expected.json
@@ -1,0 +1,61 @@
+{
+  "categories": [
+    [
+      "broken",
+      {
+        "Plain": [
+          {
+            "name": "ghost.missing",
+            "res": "broken",
+            "runs": [
+              {
+                "log": "stable/gh/ghost.missing",
+                "res": 0
+              },
+              {
+                "log": "beta/gh/ghost.missing",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/ghost/missing"
+          }
+        ]
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "broken": {
+      "Single": "#44176e"
+    }
+  },
+  "crates_count": 1,
+  "full": true,
+  "info": {
+    "broken": 1
+  },
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": true,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#44176e"
+    }
+  ],
+  "result_names": [
+    "missing repo"
+  ]
+}

--- a/tests/minicrater/missing-repo/index.html.context.expected.json
+++ b/tests/minicrater/missing-repo/index.html.context.expected.json
@@ -1,0 +1,28 @@
+{
+  "categories": [],
+  "comparison_colors": {},
+  "crates_count": 1,
+  "full": false,
+  "info": {
+    "broken": 1
+  },
+  "nav": [
+    {
+      "active": true,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [],
+  "result_names": []
+}

--- a/tests/minicrater/resource-exhaustion/downloads.html.context.expected.json
+++ b/tests/minicrater/resource-exhaustion/downloads.html.context.expected.json
@@ -1,0 +1,34 @@
+{
+  "available_archives": [
+    {
+      "name": "All the crates",
+      "path": "logs-archives/all.tar.gz"
+    },
+    {
+      "name": "test-pass crates",
+      "path": "logs-archives/test-pass.tar.gz"
+    },
+    {
+      "name": "spurious-fixed crates",
+      "path": "logs-archives/spurious-fixed.tar.gz"
+    }
+  ],
+  "crates_count": 2,
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": true,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ]
+}

--- a/tests/minicrater/resource-exhaustion/full.html.context.expected.json
+++ b/tests/minicrater/resource-exhaustion/full.html.context.expected.json
@@ -1,0 +1,98 @@
+{
+  "categories": [
+    [
+      "test-pass",
+      {
+        "Plain": [
+          {
+            "name": "build-pass (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/build-pass",
+                "res": 0
+              },
+              {
+                "log": "beta/local/build-pass",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
+          }
+        ]
+      }
+    ],
+    [
+      "spurious-fixed",
+      {
+        "Plain": [
+          {
+            "name": "memory-hungry (local)",
+            "res": "spurious-fixed",
+            "runs": [
+              {
+                "log": "stable/local/memory-hungry",
+                "res": 1
+              },
+              {
+                "log": "beta/local/memory-hungry",
+                "res": 2
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
+          }
+        ]
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "spurious-fixed": {
+      "Striped": [
+        "#5630db",
+        "#5d3dcf"
+      ]
+    },
+    "test-pass": {
+      "Single": "#72a156"
+    }
+  },
+  "crates_count": 2,
+  "full": true,
+  "info": {
+    "spurious-fixed": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": true,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#65461e"
+    }
+  ],
+  "result_names": [
+    "test passed",
+    "build OOM",
+    "test OOM"
+  ]
+}

--- a/tests/minicrater/resource-exhaustion/index.html.context.expected.json
+++ b/tests/minicrater/resource-exhaustion/index.html.context.expected.json
@@ -1,0 +1,69 @@
+{
+  "categories": [
+    [
+      "spurious-fixed",
+      {
+        "Plain": [
+          {
+            "name": "memory-hungry (local)",
+            "res": "spurious-fixed",
+            "runs": [
+              {
+                "log": "stable/local/memory-hungry",
+                "res": 0
+              },
+              {
+                "log": "beta/local/memory-hungry",
+                "res": 1
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
+          }
+        ]
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "spurious-fixed": {
+      "Striped": [
+        "#5630db",
+        "#5d3dcf"
+      ]
+    }
+  },
+  "crates_count": 2,
+  "full": false,
+  "info": {
+    "spurious-fixed": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": true,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#65461e"
+    }
+  ],
+  "result_names": [
+    "build OOM",
+    "test OOM"
+  ]
+}

--- a/tests/minicrater/small/downloads.html.context.expected.json
+++ b/tests/minicrater/small/downloads.html.context.expected.json
@@ -1,0 +1,34 @@
+{
+  "available_archives": [
+    {
+      "name": "All the crates",
+      "path": "logs-archives/all.tar.gz"
+    },
+    {
+      "name": "regressed crates",
+      "path": "logs-archives/regressed.tar.gz"
+    },
+    {
+      "name": "test-pass crates",
+      "path": "logs-archives/test-pass.tar.gz"
+    }
+  ],
+  "crates_count": 2,
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": true,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ]
+}

--- a/tests/minicrater/small/full.html.context.expected.json
+++ b/tests/minicrater/small/full.html.context.expected.json
@@ -1,0 +1,105 @@
+{
+  "categories": [
+    [
+      "regressed",
+      {
+        "Tree": {
+          "count": 0,
+          "tree": {}
+        }
+      }
+    ],
+    [
+      "regressed",
+      {
+        "RootResults": {
+          "count": 1,
+          "results": {
+            "build failed (unknown)": [
+              {
+                "name": "beta-regression (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/beta-regression",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/beta-regression",
+                    "res": 1
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    [
+      "test-pass",
+      {
+        "Plain": [
+          {
+            "name": "build-pass (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/build-pass",
+                "res": 0
+              },
+              {
+                "log": "beta/local/build-pass",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
+          }
+        ]
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "regressed": {
+      "Single": "#db3026"
+    },
+    "test-pass": {
+      "Single": "#72a156"
+    }
+  },
+  "crates_count": 2,
+  "full": true,
+  "info": {
+    "regressed": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": true,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
+    }
+  ],
+  "result_names": [
+    "test passed",
+    "build failed (unknown)"
+  ]
+}

--- a/tests/minicrater/small/index.html.context.expected.json
+++ b/tests/minicrater/small/index.html.context.expected.json
@@ -1,0 +1,80 @@
+{
+  "categories": [
+    [
+      "regressed",
+      {
+        "Tree": {
+          "count": 0,
+          "tree": {}
+        }
+      }
+    ],
+    [
+      "regressed",
+      {
+        "RootResults": {
+          "count": 1,
+          "results": {
+            "build failed (unknown)": [
+              {
+                "name": "beta-regression (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "log": "stable/local/beta-regression",
+                    "res": 0
+                  },
+                  {
+                    "log": "beta/local/beta-regression",
+                    "res": 1
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "regressed": {
+      "Single": "#db3026"
+    }
+  },
+  "crates_count": 2,
+  "full": false,
+  "info": {
+    "regressed": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": true,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
+    }
+  ],
+  "result_names": [
+    "test passed",
+    "build failed (unknown)"
+  ]
+}


### PR DESCRIPTION
This adds support for other report types in minicrater. `IndexMap` is used instead of `HashMap` to ensure consistent serialization.
Needs to be merged after #520 