### PR TITLE
Purge caches before starting an experiment when out of disk space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,11 +124,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "base64"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -348,7 +343,7 @@ dependencies = [
  "rusoto_s3 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_team_data 1.0.0 (git+https://github.com/rust-lang/team)",
- "rustwide 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustwide 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1965,10 +1960,10 @@ dependencies = [
 
 [[package]]
 name = "rustwide"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1985,6 +1980,7 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2390,6 +2386,24 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3081,7 +3095,6 @@ dependencies = [
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
@@ -3281,7 +3294,7 @@ dependencies = [
 "checksum rust_team_data 1.0.0 (git+https://github.com/rust-lang/team)" = "<none>"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustwide 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bdbd298db0cc86ada7eec52ccec5741cb1391c689802411aa04577d859013e70"
+"checksum rustwide 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "417d578ebc7fa963bcd06f365f7987c091abeba70eac22dba94b7fd922a95c09"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
@@ -3328,6 +3341,8 @@ dependencies = [
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+"checksum thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6e93c78d23cc61aa245a8acd2c4a79c4d7fa7fb5c3ca90d5737029f043a84895"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ hmac = "0.7"
 sha-1 = "0.8"
 rust_team_data = { git = "https://github.com/rust-lang/team" }
 systemstat = "0.1.4"
-rustwide = { version = "0.8.0", features = ["unstable"] }
+rustwide = { version = "0.10.0", features = ["unstable", "unstable-toolchain-ci"] }
 percent-encoding = "2.1.0"
 remove_dir_all = "0.5.2"
 ctrlc = "3.1.3"

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -167,7 +167,7 @@ fn run_cargo<DB: WriteResults>(
             } else if !error_codes.is_empty() {
                 Err(e.context(FailureReason::CompilerError(error_codes)).into())
             } else {
-                Err(e)
+                Err(e.into())
             }
         }
     }

--- a/src/utils/disk_usage.rs
+++ b/src/utils/disk_usage.rs
@@ -1,0 +1,53 @@
+use crate::prelude::*;
+use std::path::Path;
+use systemstat::{Filesystem, Platform, System};
+
+pub(crate) struct DiskUsage {
+    mount_point: String,
+    usage: f32,
+}
+
+impl DiskUsage {
+    pub(crate) fn fetch() -> Fallible<Self> {
+        let fs = current_mount()?;
+        Ok(Self {
+            mount_point: fs.fs_mounted_on.clone(),
+            usage: (fs.total.as_usize() - fs.free.as_usize()) as f32 / fs.total.as_usize() as f32,
+        })
+    }
+
+    pub(crate) fn is_threshold_reached(&self, threshold: f32) -> bool {
+        let usage = (self.usage * 100.0) as u8;
+        if self.usage < threshold {
+            info!("{} disk usage at {}%", self.mount_point, usage);
+            false
+        } else {
+            warn!(
+                "{} disk usage at {}%, which is over the threshold of {}%",
+                self.mount_point,
+                usage,
+                (threshold * 100.0) as u8
+            );
+            true
+        }
+    }
+}
+
+fn current_mount() -> Fallible<Filesystem> {
+    let current_dir = crate::utils::path::normalize_path(&crate::dirs::WORK_DIR);
+    let system = System::new();
+
+    let mut found = None;
+    let mut found_pos = std::usize::MAX;
+    for mount in system.mounts()?.into_iter() {
+        let path = Path::new(&mount.fs_mounted_on);
+        for (i, ancestor) in current_dir.ancestors().enumerate() {
+            if ancestor == path && i < found_pos {
+                found_pos = i;
+                found = Some(mount);
+                break;
+            }
+        }
+    }
+    found.ok_or_else(|| failure::err_msg("failed to find the current mount"))
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod hex;
 pub(crate) mod http;
 #[macro_use]
 mod macros;
+pub(crate) mod disk_usage;
 pub(crate) mod path;
 pub(crate) mod serialize;
 pub mod size;


### PR DESCRIPTION
This PR changes the agent to purge all caches before starting an experiment if there is less than half disk space free on the host machine. This will make running Crater on "low" disk space hosts way less painful.

In theory this only runs the cleanup code when an experiment finishes, but in practice it will run it every 1000 built crates, since distributed runs works internally by splitting an experiment in 1000 crates chunks.

r? @Mark-Simulacrum 