### PR TITLE
Add a mode for reading docs.rs metadata when running rustdoc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "difference",
+ "docsrs-metadata",
  "dotenv",
  "env_logger",
  "failure",
@@ -684,6 +685,16 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "docsrs-metadata"
+version = "0.1.0"
+source = "git+https://github.com/rust-lang/docs.rs/#97080011f4e3007c22a0b181d9820e6e980c5bf7"
+dependencies = [
+ "serde",
+ "thiserror",
+ "toml 0.5.7",
+]
 
 [[package]]
 name = "dotenv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ crates-index = "0.16.2"
 crossbeam-utils = "0.5"
 crossbeam-channel = "0.5"
 csv = "1.0.2"
+docsrs-metadata = { git = "https://github.com/rust-lang/docs.rs/" }
 dotenv = "0.13"
 failure = "0.1.3"
 flate2 = "1"

--- a/local-crates/docs-rs-features/Cargo.toml
+++ b/local-crates/docs-rs-features/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "docs-rs-features"
+version = "0.1.0"
+authors = ["Joshua Nelson <jyn514@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[package.metadata.docs.rs]
+features = ["docs_rs_feature"]
+
+[features]
+docs_rs_feature = []

--- a/local-crates/docs-rs-features/src/lib.rs
+++ b/local-crates/docs-rs-features/src/lib.rs
@@ -1,0 +1,6 @@
+#[cfg(feature = "docs_rs_feature")]
+compile_error!("oh no, a hidden regression!");
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/runner/unstable_features.rs
+++ b/src/runner/unstable_features.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::results::TestResult;
 use crate::results::WriteResults;
 use crate::runner::tasks::TaskCtx;
-use cargo_metadata::PackageId;
+use cargo_metadata::Package;
 use rustwide::Build;
 use std::collections::HashSet;
 use std::path::Path;
@@ -11,7 +11,7 @@ use walkdir::{DirEntry, WalkDir};
 pub(super) fn find_unstable_features<DB: WriteResults>(
     _ctx: &TaskCtx<DB>,
     build: &Build,
-    _local_packages_id: &HashSet<PackageId>,
+    _local_packages_id: &[Package],
 ) -> Fallible<TestResult> {
     let mut features = HashSet::new();
 

--- a/tests/minicrater/doc/config.toml
+++ b/tests/minicrater/doc/config.toml
@@ -1,0 +1,27 @@
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
+
+[server.labels]
+remove = "^S-"
+experiment-queued = "S-waiting-on-crater"
+experiment-completed = "S-waiting-on-review"
+
+[server.distributed]
+chunk-size = 32
+
+[demo-crates]
+crates = []
+github-repos = []
+local-crates = ["build-pass", "docs-rs-features"]
+
+[sandbox]
+memory-limit = "512M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
+
+[crates]
+
+[github-repos]
+
+[local-crates]

--- a/tests/minicrater/doc/downloads.html.context.expected.json
+++ b/tests/minicrater/doc/downloads.html.context.expected.json
@@ -5,31 +5,15 @@
       "path": "logs-archives/all.tar.gz"
     },
     {
-      "name": "regressed crates",
-      "path": "logs-archives/regressed.tar.gz"
-    },
-    {
-      "name": "fixed crates",
-      "path": "logs-archives/fixed.tar.gz"
-    },
-    {
-      "name": "broken crates",
-      "path": "logs-archives/broken.tar.gz"
-    },
-    {
-      "name": "build-fail crates",
-      "path": "logs-archives/build-fail.tar.gz"
-    },
-    {
       "name": "test-pass crates",
       "path": "logs-archives/test-pass.tar.gz"
     },
     {
-      "name": "test-fail crates",
-      "path": "logs-archives/test-fail.tar.gz"
+      "name": "build-fail crates",
+      "path": "logs-archives/build-fail.tar.gz"
     }
   ],
-  "crates_count": 17,
+  "crates_count": 2,
   "nav": [
     {
       "active": false,

--- a/tests/minicrater/doc/full.html.context.expected.json
+++ b/tests/minicrater/doc/full.html.context.expected.json
@@ -1,0 +1,91 @@
+{
+  "categories": [
+    [
+      "test-pass",
+      {
+        "Plain": [
+          {
+            "name": "build-pass (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/build-pass",
+                "res": 0
+              },
+              {
+                "log": "beta/local/build-pass",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
+          }
+        ]
+      }
+    ],
+    [
+      "build-fail",
+      {
+        "Plain": [
+          {
+            "name": "docs-rs-features (local)",
+            "res": "build-fail",
+            "runs": [
+              {
+                "log": "stable/local/docs-rs-features",
+                "res": 1
+              },
+              {
+                "log": "beta/local/docs-rs-features",
+                "res": 1
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/docs-rs-features"
+          }
+        ]
+      }
+    ]
+  ],
+  "comparison_colors": {
+    "build-fail": {
+      "Single": "#65461e"
+    },
+    "test-pass": {
+      "Single": "#72a156"
+    }
+  },
+  "crates_count": 2,
+  "full": true,
+  "info": {
+    "build-fail": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": false,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": true,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
+    }
+  ],
+  "result_names": [
+    "test passed",
+    "build failed (unknown)"
+  ]
+}

--- a/tests/minicrater/doc/index.html.context.expected.json
+++ b/tests/minicrater/doc/index.html.context.expected.json
@@ -1,0 +1,29 @@
+{
+  "categories": [],
+  "comparison_colors": {},
+  "crates_count": 2,
+  "full": false,
+  "info": {
+    "build-fail": 1,
+    "test-pass": 1
+  },
+  "nav": [
+    {
+      "active": true,
+      "label": "Summary",
+      "url": "index.html"
+    },
+    {
+      "active": false,
+      "label": "Full report",
+      "url": "full.html"
+    },
+    {
+      "active": false,
+      "label": "Downloads",
+      "url": "downloads.html"
+    }
+  ],
+  "result_colors": [],
+  "result_names": []
+}

--- a/tests/minicrater/doc/markdown.md.context.expected.json
+++ b/tests/minicrater/doc/markdown.md.context.expected.json
@@ -1,0 +1,9 @@
+{
+  "categories": [],
+  "crates_count": 2,
+  "full": false,
+  "info": {
+    "build-fail": 1,
+    "test-pass": 1
+  }
+}

--- a/tests/minicrater/doc/results.expected.json
+++ b/tests/minicrater/doc/results.expected.json
@@ -1,0 +1,40 @@
+{
+  "crates": [
+    {
+      "krate": {
+        "Local": "build-pass"
+      },
+      "name": "build-pass (local)",
+      "res": "test-pass",
+      "runs": [
+        {
+          "log": "stable/local/build-pass",
+          "res": "test-pass"
+        },
+        {
+          "log": "beta/local/build-pass",
+          "res": "test-pass"
+        }
+      ],
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
+    },
+    {
+      "krate": {
+        "Local": "docs-rs-features"
+      },
+      "name": "docs-rs-features (local)",
+      "res": "build-fail",
+      "runs": [
+        {
+          "log": "stable/local/docs-rs-features",
+          "res": "build-fail:unknown"
+        },
+        {
+          "log": "beta/local/docs-rs-features",
+          "res": "build-fail:unknown"
+        }
+      ],
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/docs-rs-features"
+    }
+  ]
+}

--- a/tests/minicrater/full/full.html.context.expected.json
+++ b/tests/minicrater/full/full.html.context.expected.json
@@ -265,6 +265,21 @@
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
           },
           {
+            "name": "docs-rs-features (local)",
+            "res": "test-pass",
+            "runs": [
+              {
+                "log": "stable/local/docs-rs-features",
+                "res": 0
+              },
+              {
+                "log": "beta/local/docs-rs-features",
+                "res": 0
+              }
+            ],
+            "url": "https://github.com/rust-lang/crater/tree/master/local-crates/docs-rs-features"
+          },
+          {
             "name": "missing-examples (local)",
             "res": "test-pass",
             "runs": [
@@ -362,7 +377,7 @@
       "Single": "#72a156"
     }
   },
-  "crates_count": 16,
+  "crates_count": 17,
   "full": true,
   "info": {
     "broken": 2,
@@ -371,7 +386,7 @@
     "regressed": 4,
     "skipped": 1,
     "test-fail": 1,
-    "test-pass": 4
+    "test-pass": 5
   },
   "nav": [
     {

--- a/tests/minicrater/full/index.html.context.expected.json
+++ b/tests/minicrater/full/index.html.context.expected.json
@@ -165,7 +165,7 @@
       "Single": "#db3026"
     }
   },
-  "crates_count": 16,
+  "crates_count": 17,
   "full": false,
   "info": {
     "broken": 2,
@@ -174,7 +174,7 @@
     "regressed": 4,
     "skipped": 1,
     "test-fail": 1,
-    "test-pass": 4
+    "test-pass": 5
   },
   "nav": [
     {

--- a/tests/minicrater/full/markdown.md.context.expected.json
+++ b/tests/minicrater/full/markdown.md.context.expected.json
@@ -156,7 +156,7 @@
       }
     ]
   ],
-  "crates_count": 16,
+  "crates_count": 17,
   "full": false,
   "info": {
     "broken": 2,
@@ -165,6 +165,6 @@
     "regressed": 4,
     "skipped": 1,
     "test-fail": 1,
-    "test-pass": 4
+    "test-pass": 5
   }
 }

--- a/tests/minicrater/full/results.expected.json
+++ b/tests/minicrater/full/results.expected.json
@@ -128,6 +128,24 @@
     },
     {
       "krate": {
+        "Local": "docs-rs-features"
+      },
+      "name": "docs-rs-features (local)",
+      "res": "test-pass",
+      "runs": [
+        {
+          "log": "stable/local/docs-rs-features",
+          "res": "test-pass"
+        },
+        {
+          "log": "beta/local/docs-rs-features",
+          "res": "test-pass"
+        }
+      ],
+      "url": "https://github.com/rust-lang/crater/tree/master/local-crates/docs-rs-features"
+    },
+    {
+      "krate": {
         "Local": "error-code"
       },
       "name": "error-code (local)",

--- a/tests/minicrater/mod.rs
+++ b/tests/minicrater/mod.rs
@@ -42,6 +42,13 @@ minicrater! {
         ..Default::default()
     },
 
+    doc_small {
+        ex: "doc",
+        crate_select: "demo",
+        mode: "rustdoc",
+        ..Default::default()
+    },
+
     single_thread_missing_repo {
         ex: "missing-repo",
         crate_select: "dummy",


### PR DESCRIPTION
Closes https://github.com/rust-lang/crater/issues/532

Before merging, I need to publish the `docsrs-metadata` package to crates.io so crater doesn't depend on a git version.