### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -713,7 +713,7 @@ mod tests {
             name: "hello-rs".into(),
             sha: None,
         };
-        let gh = Crate::GitHub(repo.clone());
+        let gh = Crate::GitHub(repo);
 
         let index = Index::new(WORK_DIR.join("crates.io-index"));
         index.retrieve_or_update().unwrap();
@@ -745,7 +745,7 @@ mod tests {
             name: "hello-rs".into(),
             sha: None,
         };
-        let gh = Crate::GitHub(repo.clone());
+        let gh = Crate::GitHub(repo);
 
         assert_eq!(
             crate_to_url(&gh).unwrap(),
@@ -884,7 +884,7 @@ mod tests {
             name: "hello-rs".into(),
             sha: Some("f00".into()),
         };
-        let gh = Crate::GitHub(repo.clone());
+        let gh = Crate::GitHub(repo);
         let reg = Crate::Registry(RegistryCrate {
             name: "syn".into(),
             version: "1.0.0".into(),

--- a/src/results/db.rs
+++ b/src/results/db.rs
@@ -230,7 +230,7 @@ mod tests {
         WriteResults,
     };
     use crate::toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
-    use base64;
+
     use std::collections::BTreeSet;
 
     #[test]
@@ -434,7 +434,7 @@ mod tests {
 
         assert_eq!(
             results.load_log(&ex, &MAIN_TOOLCHAIN, &updated).unwrap(),
-            Some(EncodedLog::Plain("foo".as_bytes().to_vec()))
+            Some(EncodedLog::Plain(b"foo".to_vec()))
         );
         assert_eq!(
             results

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -62,11 +62,7 @@ pub(super) enum WalkResult {
 
 impl WalkResult {
     pub(super) fn is_finished(&self) -> bool {
-        if let WalkResult::Finished = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, WalkResult::Finished)
     }
 }
 

--- a/tests/minicrater/driver.rs
+++ b/tests/minicrater/driver.rs
@@ -59,13 +59,13 @@ trait Compare {
             let actual_file = ex_dir.join(expand_file_names(file, ".actual"));
             let expected_file = ex_dir.join(expand_file_names(file, ".expected"));
             // Load actual report
-            let raw_report =
-                ::std::fs::read(file_dir.join(file)).expect(&format!("failed to read {}", file));
+            let raw_report = ::std::fs::read(file_dir.join(file))
+                .unwrap_or_else(|_| panic!("failed to read {}", file));
             // Test report format
             let actual_report = self.format(raw_report);
 
             // Load the expected report
-            let expected_report = ::std::fs::read(&expected_file).unwrap_or(Vec::new());
+            let expected_report = ::std::fs::read(&expected_file).unwrap_or_default();
 
             // Write the actual JSON report
             ::std::fs::write(&actual_file, &actual_report)
@@ -92,7 +92,7 @@ trait Compare {
                 failed = true;
             }
         }
-        return failed;
+        failed
     }
 }
 


### PR DESCRIPTION
This fixes the build failure in
https://github.com/rust-lang/crater/pull/543/checks?check_run_id=1324273363.

This commit can be replicated with
cargo clippy --fix -Z unstable-options && cargo fmt`.