### PR TITLE
Skip mpsc channels in report generation and disk cleaning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@
     clippy::unnecessary_wraps,
     clippy::needless_question_mark,
     clippy::vec_init_then_push,
-    clippy::upper_case_acronyms
+    clippy::upper_case_acronyms,
+    clippy::mutex_atomic
 )]
 
 pub mod actions;


### PR DESCRIPTION
I doubt this is the cause of our deadlocks, but std's mpsc channels have had some bugs in the past around timeouts IIRC. In any case, the new implementation feels just simpler to me, so an improvement regardless.