### PR TITLE
Back off from running job on high load

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -112,17 +112,15 @@ pub fn run_ex<DB: WriteResults + Sync>(
         let mut threads = Vec::new();
 
         for worker in &workers {
-            let join =
-                scope
-                    .builder()
-                    .name(worker.name().into())
-                    .spawn(move || match worker.run() {
-                        Ok(()) => Ok(()),
-                        Err(r) => {
-                            log::warn!("worker {} failed: {:?}", worker.name(), r);
-                            Err(r)
-                        }
-                    })?;
+            let join = scope.builder().name(worker.name().into()).spawn(move || {
+                match worker.run(threads_count) {
+                    Ok(()) => Ok(()),
+                    Err(r) => {
+                        log::warn!("worker {} failed: {:?}", worker.name(), r);
+                        Err(r)
+                    }
+                }
+            })?;
             threads.push(join);
         }
         let disk_watcher_thread =


### PR DESCRIPTION
This is realistically just an experiment - I have no statistics to show this will actually be better. But I also figure that it is relatively low cost for us to deploy and see what our metrics look like; if there is an improvement, great, if not, we can revert this pretty quickly (or experiment with other values). We definitely see on all crater machines that there is usually quite a bit of traffic right now towards the CPU.

It is also likely that this might just lead to all the thread backing off, and not much work getting done. If so, we'd likely want to reconsider. But this is at least an attempt at reducing the scheduled load.