### PR TITLE
Update rustwide to 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "rustwide"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689b0858f1118c80702a03f9cee1ab09955b55b4166b72457859212790afe129"
+checksum = "836d992b62e3d6559d0ef9fdd666d59942037dadca58c0625c896fc223e31ab3"
 dependencies = [
  "attohttpc",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ hmac = "0.7"
 sha-1 = "0.8"
 rust_team_data = { git = "https://github.com/rust-lang/team" }
 systemstat = "0.1.4"
-rustwide = { version = "0.13.0", features = ["unstable", "unstable-toolchain-ci"] }
+rustwide = { version = "0.13.1", features = ["unstable", "unstable-toolchain-ci"] }
 percent-encoding = "2.1.0"
 remove_dir_all = "0.5.2"
 ctrlc = "3.1.3"

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,7 @@ pub trait FailExt {
 }
 
 impl FailExt for dyn Fail {
+    #[allow(clippy::manual_map)]
     fn downcast_ctx<T: Fail>(&self) -> Option<&T> {
         if let Some(res) = self.downcast_ref::<T>() {
             Some(res)

--- a/src/runner/unstable_features.rs
+++ b/src/runner/unstable_features.rs
@@ -77,6 +77,7 @@ fn eat_token<'a>(s: Option<&'a str>, tok: &str) -> Option<&'a str> {
 
 fn eat_whitespace(s: Option<&str>) -> Option<&str> {
     s.and_then(|s| {
+        #[allow(clippy::manual_map)]
         if let Some(i) = s.find(|c: char| !c.is_whitespace()) {
             Some(&s[i..])
         } else {


### PR DESCRIPTION
This includes https://github.com/rust-lang/rustwide/pull/61 which addresses
breakage in the beta crater run.