### PR TITLE
Retain 5 GB of slack space, rather than 15% of the disk

### DIFF
--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -20,7 +20,10 @@ use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 
 const DISK_SPACE_WATCHER_INTERVAL: Duration = Duration::from_secs(300);
-const DISK_SPACE_WATCHER_THRESHOLD: f32 = 0.85;
+// We expect 5 gigabytes of free space to be retained. Don't use a percentage as
+// we then leave more free space 'free' on larger disks, which doesn't make
+// sense: we want to purge as rarely as possible, and not leave slack space.
+const DISK_SPACE_WATCHER_THRESHOLD: u32 = 5;
 
 #[derive(Debug, Fail)]
 #[fail(display = "overridden task result to {}", _0)]

--- a/src/runner/worker.rs
+++ b/src/runner/worker.rs
@@ -140,14 +140,14 @@ impl<'a, DB: WriteResults + Sync> Worker<'a, DB> {
 
 pub(super) struct DiskSpaceWatcher<'a, DB: WriteResults + Sync> {
     interval: Duration,
-    threshold: f32,
+    threshold: u32,
     workers: &'a [Worker<'a, DB>],
     should_stop: Mutex<bool>,
     waiter: Condvar,
 }
 
 impl<'a, DB: WriteResults + Sync> DiskSpaceWatcher<'a, DB> {
-    pub(super) fn new(interval: Duration, threshold: f32, workers: &'a [Worker<'a, DB>]) -> Self {
+    pub(super) fn new(interval: Duration, threshold: u32, workers: &'a [Worker<'a, DB>]) -> Self {
         DiskSpaceWatcher {
             interval,
             threshold,
@@ -187,7 +187,7 @@ impl<'a, DB: WriteResults + Sync> DiskSpaceWatcher<'a, DB> {
             }
         };
 
-        if usage.is_threshold_reached(self.threshold) {
+        if !usage.has_gigabytes_left(self.threshold) {
             warn!("running the scheduled thread cleanup");
             for worker in self.workers {
                 worker.schedule_target_dir_cleanup();


### PR DESCRIPTION
On a 2 TB disk, 15% is 300 GB: way more than necessary for some margin of safety. In general, on large disks, this is always going to be the case, whereas in smaller disks 15% slack space may be pretty small. Specify free space as a constant number of gigabytes instead. We retain the 50% margin for clearing out the caches (e.g., downloaded crates, git repositories) because those are generally less harmful to our performance and we prefer to clear them out rather than artifacts. Trying to balance the needle on a finer point (e.g., going for 100 GB free there) doesn't seem warranted.

In theory it might be better to have it be worker-dependent (e.g., 1 GB per worker) but that seems more complicated and likely not really necessary.

In practice the 2TB disks take ~19 hours to fill up with 14 workers, so we're already running pretty rarely: I don't expect any significant wins. Nevertheless, it does look like we speed up as the disk space fills up (as one would hope), so it seems likely that this should be a win over the multi-day builds we have.