### PR TITLE
Add `rusty_v8` to the list of spurious failures

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -97,6 +97,7 @@ read-process-memory = { skip-tests = true } # flaky tests
 restson = { skip-tests = true } # uses HTTP requests
 rspotify = { slow = true } # slow build
 rustlearn = { skip-tests = true } # non-deterministic
+rusty_v8 = { broken = true } # depends on network
 s_app_dir = { skip-tests = true } # flaky tests
 sacn = { skip-tests = true } # Tests just fail if RUST_TEST_THREADS > 1 -author
 sbrsk = { skip-tests = true } # flaky tests


### PR DESCRIPTION
Here's an example failure: https://crater-reports.s3.amazonaws.com/pr-87050/try%23ddfd70ee3c3748e597b32f416b0d15a4f6e37685/gh/DiscoreMe.mydeno/log.txt

```
[INFO] [stderr]    Compiling rusty_v8 v0.16.0
[INFO] [stderr] error: failed to run custom build command for `rusty_v8 v0.16.0`
[INFO] [stderr]
[INFO] [stderr] Caused by:
[INFO] [stderr]   process didn't exit successfully: `/opt/rustwide/target/debug/build/rusty_v8-9f24d36fc8d2f58d/build-script-build` (exit status: 101)
[INFO] [stderr]   --- stdout
[INFO] [stderr]   download lockfile: "/opt/rustwide/target/debug/build/lib_download.fslock"
[INFO] [stderr]   static lib URL: https://github.com/denoland/rusty_v8/releases/download/v0.16.0/librusty_v8_debug_x86_64-unknown-linux-gnu.a
[INFO] [stderr]   cargo:rustc-link-search=/opt/rustwide/target/debug/gn_out/obj
[INFO] [stderr]   Downloading https://github.com/denoland/rusty_v8/releases/download/v0.16.0/librusty_v8_debug_x86_64-unknown-linux-gnu.a
[INFO] [stderr]   Downloading https://github.com/denoland/rusty_v8/releases/download/v0.16.0/librusty_v8_debug_x86_64-unknown-linux-gnu.a...
[INFO] [stderr]   <urlopen error [Errno -3] Temporary failure in name resolution>
[INFO] [stderr]   Retrying in 5 s ...
[INFO] [stderr]   Downloading https://github.com/denoland/rusty_v8/releases/download/v0.16.0/librusty_v8_debug_x86_64-unknown-linux-gnu.a...
[INFO] [stderr]   <urlopen error [Errno -3] Temporary failure in name resolution>
[INFO] [stderr]   Retrying in 10 s ...
[INFO] [stderr]   Downloading https://github.com/denoland/rusty_v8/releases/download/v0.16.0/librusty_v8_debug_x86_64-unknown-linux-gnu.a...
[INFO] [stderr]   <urlopen error [Errno -3] Temporary failure in name resolution>
[INFO] [stderr]   Retrying in 20 s ...
[INFO] [stderr]   Downloading https://github.com/denoland/rusty_v8/releases/download/v0.16.0/librusty_v8_debug_x86_64-unknown-linux-gnu.a...
[INFO] [stderr]   <urlopen error [Errno -3] Temporary failure in name resolution>
[INFO] [stderr]   Python downloader failed, trying with curl.
[INFO] [stderr]
[INFO] [stderr]   --- stderr
[INFO] [stderr]   Traceback (most recent call last):
[INFO] [stderr]     File "./tools/download_file.py", line 64, in <module>
[INFO] [stderr]       sys.exit(main())
[INFO] [stderr]     File "./tools/download_file.py", line 59, in main
[INFO] [stderr]       DownloadUrl(args.url, f)
[INFO] [stderr]     File "./tools/download_file.py", line 45, in DownloadUrl
[INFO] [stderr]       raise e
[INFO] [stderr]   urllib2.URLError: <urlopen error [Errno -3] Temporary failure in name resolution>
[INFO] [stderr]   thread 'main' panicked at 'assertion failed: status.success()', /opt/rustwide/cargo-home/registry/src/github.com-1ecc6299db9ec823/rusty_v8-0.16.0/build.rs:276:3
```