### PR TITLE
Don't uninstall the stable toolchain.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,9 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "rustwide"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d992b62e3d6559d0ef9fdd666d59942037dadca58c0625c896fc223e31ab3"
+checksum = "fad1c7516d4138e9f7bf4b0f56d41585f5aa1ba57dce6df34b4e90ba9db7d18b"
 dependencies = [
  "attohttpc",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ hmac = "0.7"
 sha-1 = "0.8"
 rust_team_data = { git = "https://github.com/rust-lang/team" }
 systemstat = "0.1.4"
-rustwide = { version = "0.13.1", features = ["unstable", "unstable-toolchain-ci"] }
+rustwide = { version = "0.14.0", features = ["unstable", "unstable-toolchain-ci"] }
 percent-encoding = "2.1.0"
 remove_dir_all = "0.5.2"
 ctrlc = "3.1.3"

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -70,7 +70,9 @@ pub fn run_ex<DB: WriteResults + Sync>(
     // proceed slightly faster than it would otherwise.
     for tc in workspace.installed_toolchains()? {
         // But don't uninstall it if we're going to reinstall in a couple lines.
-        if !ex.toolchains.iter().any(|t| tc == t.source) {
+        // And don't uninstall stable, since that is mainly used for
+        // installing tools.
+        if !tc.is_needed_by_rustwide() && !ex.toolchains.iter().any(|t| tc == t.source) {
             tc.uninstall(workspace)?;
         }
     }


### PR DESCRIPTION
#572 added some code to uninstall existing toolchains.  However, this caused the `stable` toolchain to always be uninstalled. This toolchain is used for installing tools like rustup-toolchain-install-master.  Uninstalling it causes it to be redownloaded every time crater is run locally, making it difficult to use it locally since it can take about a minute for me to download.

Pietro said to add a test for stable here.  Unfortunately rustwide doesn't provide public access to anything other than the display impl to test this.  I can make some changes to rustwide if a cleaner approach is desired.
