### PR TITLE
Add halg to skipped crates

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -131,6 +131,7 @@ toql_derive = { skip-tests = true } # flaky test ("Sometimes failes becuse join 
 
 [github-repos]
 # "org_name/repo_name" = { option = true }
+"davips/halg" = { skip = true }
 "fromheten/plato" = { skip-tests = true } # flaky tests
 "jafow/pals" = { skip-tests = true } # flaky tests
 "johnedmonds/chance" = { skip-tests = true } # flaky tests


### PR DESCRIPTION
This crate uses rustversion and defines a function only in stable and nightly, not beta, so it will always fail.

Log: https://crater-reports.s3.amazonaws.com/beta-1.55-1/beta-2021-08-01/gh/davips.halg/log.txt