### PR TITLE
Make it possible to run the crater server without a github bot

### DIFF
--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -120,7 +120,7 @@ impl ACL {
         };
 
         if let Some(github) = github {
-            acl.refresh_cache(&github.github)?;
+            acl.refresh_cache(&github.api)?;
         }
         Ok(acl)
     }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::prelude::*;
 use crate::server::github::{GitHub, GitHubApi};
-use crate::server::{Data, HttpError};
+use crate::server::{Data, GithubData, HttpError};
 use http::header::{HeaderMap, AUTHORIZATION, USER_AGENT};
 use regex::Regex;
 use rust_team_data::v1 as team_data;
@@ -98,7 +98,7 @@ pub struct ACL {
 }
 
 impl ACL {
-    pub fn new(config: &Config, github: &GitHubApi) -> Fallible<Self> {
+    pub fn new(config: &Config, github: Option<&GithubData>) -> Fallible<Self> {
         let mut users = Vec::new();
         let mut teams = Vec::new();
 
@@ -119,7 +119,9 @@ impl ACL {
             teams,
         };
 
-        acl.refresh_cache(github)?;
+        if let Some(github) = github {
+            acl.refresh_cache(&github.github)?;
+        }
         Ok(acl)
     }
 

--- a/src/server/github.rs
+++ b/src/server/github.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::server::tokens::Tokens;
+use crate::server::tokens::BotTokens;
 use crate::utils;
 use http::header::AUTHORIZATION;
 use http::Method;
@@ -32,9 +32,9 @@ pub struct GitHubApi {
 }
 
 impl GitHubApi {
-    pub fn new(tokens: &Tokens) -> Self {
+    pub fn new(tokens: &BotTokens) -> Self {
         GitHubApi {
-            token: tokens.bot.api_token.clone(),
+            token: tokens.api_token.clone(),
         }
     }
 

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::server::github::GitHub;
-use crate::server::Data;
+use crate::server::{Data, GithubData};
 
 pub enum Label {
     ExperimentQueued,
@@ -48,7 +48,7 @@ impl Message {
         self
     }
 
-    pub fn send(mut self, issue_url: &str, data: &Data) -> Fallible<()> {
+    pub fn send(mut self, issue_url: &str, data: &Data, github_data: &GithubData) -> Fallible<()> {
         // Always add a note at the bottom explaining what this is
         self = self.note(
             "information_source",
@@ -67,7 +67,7 @@ impl Message {
             message.push_str(&format!("\n:{}: {}", line.emoji, line.content));
         }
 
-        data.github.post_comment(issue_url, &message)?;
+        github_data.github.post_comment(issue_url, &message)?;
 
         if let Some(label) = self.new_label {
             let label = match label {
@@ -78,18 +78,20 @@ impl Message {
             // Remove all the labels matching the provided regex
             // If the label is already present don't reapply it though
             let regex = &data.config.server.labels.remove;
-            let current_labels = data.github.list_labels(issue_url)?;
+            let current_labels = github_data.github.list_labels(issue_url)?;
             let mut label_already_present = false;
             for current_label in &current_labels {
                 if current_label.name == *label {
                     label_already_present = true;
                 } else if regex.is_match(&current_label.name) {
-                    data.github.remove_label(issue_url, &current_label.name)?;
+                    github_data
+                        .github
+                        .remove_label(issue_url, &current_label.name)?;
                 }
             }
 
             if !label_already_present {
-                data.github.add_label(issue_url, label)?;
+                github_data.github.add_label(issue_url, label)?;
             }
         }
 

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -67,7 +67,7 @@ impl Message {
             message.push_str(&format!("\n:{}: {}", line.emoji, line.content));
         }
 
-        github_data.github.post_comment(issue_url, &message)?;
+        github_data.api.post_comment(issue_url, &message)?;
 
         if let Some(label) = self.new_label {
             let label = match label {
@@ -78,20 +78,20 @@ impl Message {
             // Remove all the labels matching the provided regex
             // If the label is already present don't reapply it though
             let regex = &data.config.server.labels.remove;
-            let current_labels = github_data.github.list_labels(issue_url)?;
+            let current_labels = github_data.api.list_labels(issue_url)?;
             let mut label_already_present = false;
             for current_label in &current_labels {
                 if current_label.name == *label {
                     label_already_present = true;
                 } else if regex.is_match(&current_label.name) {
                     github_data
-                        .github
+                        .api
                         .remove_label(issue_url, &current_label.name)?;
                 }
             }
 
             if !label_already_present {
-                github_data.github.add_label(issue_url, label)?;
+                github_data.api.add_label(issue_url, label)?;
             }
         }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -16,7 +16,7 @@ use crate::prelude::*;
 use crate::server::agents::Agents;
 use crate::server::auth::ACL;
 use crate::server::github::{GitHub, GitHubApi};
-use crate::server::tokens::Tokens;
+use crate::server::tokens::{BotTokens, Tokens};
 use http::{self, header::HeaderValue, Response};
 use hyper::Body;
 use metrics::Metrics;
@@ -39,9 +39,7 @@ pub enum HttpError {
 
 #[derive(Clone)]
 pub struct Data {
-    pub bot_username: String,
     pub config: Config,
-    pub github: GitHubApi,
     pub tokens: Tokens,
     pub agents: Agents,
     pub db: Database,
@@ -50,21 +48,37 @@ pub struct Data {
     pub metrics: Metrics,
 }
 
+#[derive(Clone)]
+pub struct GithubData {
+    pub bot_username: String,
+    pub github: GitHubApi,
+    pub tokens: BotTokens,
+}
+
 pub fn run(config: Config, bind: SocketAddr) -> Fallible<()> {
     let db = Database::open()?;
     let tokens = tokens::Tokens::load()?;
-    let github = GitHubApi::new(&tokens);
+    let github_data = tokens
+        .bot
+        .as_ref()
+        .cloned()
+        .map(|tokens| {
+            let github = GitHubApi::new(&tokens);
+            let bot_username = github.username()?;
+            info!("bot username: {}", bot_username);
+            Fallible::Ok(GithubData {
+                github,
+                bot_username,
+                tokens,
+            })
+        })
+        .transpose()?;
     let agents = Agents::new(db.clone(), &tokens)?;
-    let bot_username = github.username()?;
-    let acl = ACL::new(&config, &github)?;
+    let acl = ACL::new(&config, github_data.as_ref())?;
     let metrics = Metrics::new()?;
 
-    info!("bot username: {}", bot_username);
-
     let data = Data {
-        bot_username,
         config,
-        github,
         tokens,
         agents,
         db,
@@ -75,18 +89,26 @@ pub fn run(config: Config, bind: SocketAddr) -> Fallible<()> {
 
     let mutex = Arc::new(Mutex::new(data.clone()));
 
-    data.reports_worker.spawn(data.clone());
+    data.reports_worker.spawn(data.clone(), github_data.clone());
     cronjobs::spawn(data.clone());
 
     info!("running server on {}...", bind);
 
     let data = Arc::new(data);
+    let github_data = github_data.map(Arc::new);
 
     let routes = warp::any()
         .and(
             warp::any()
-                .and(warp::path("webhooks").and(routes::webhooks::routes(data.clone())))
-                .or(warp::path("agent-api").and(routes::agent::routes(data.clone(), mutex)))
+                .and(
+                    warp::path("webhooks")
+                        .and(routes::webhooks::routes(data.clone(), github_data.clone())),
+                )
+                .or(warp::path("agent-api").and(routes::agent::routes(
+                    data.clone(),
+                    mutex,
+                    github_data,
+                )))
                 .unify()
                 .or(warp::path("metrics").and(routes::metrics::routes(data.clone())))
                 .unify()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -51,7 +51,7 @@ pub struct Data {
 #[derive(Clone)]
 pub struct GithubData {
     pub bot_username: String,
-    pub github: GitHubApi,
+    pub api: GitHubApi,
     pub tokens: BotTokens,
 }
 
@@ -67,7 +67,7 @@ pub fn run(config: Config, bind: SocketAddr) -> Fallible<()> {
             let bot_username = github.username()?;
             info!("bot username: {}", bot_username);
             Fallible::Ok(GithubData {
-                github,
+                api: github,
                 bot_username,
                 tokens,
             })

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -226,7 +226,7 @@ fn endpoint_error(
                     "sos",
                     "Can someone from the infra team check in on this? @rust-lang/infra",
                 )
-                .send(&github_issue.api_url, &data, &github_data)?;
+                .send(&github_issue.api_url, &data, github_data)?;
         }
     }
     Ok(ApiResponse::Success { result: true }.into_response()?)

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -5,7 +5,7 @@ use crate::results::{DatabaseDB, EncodingType, ProgressData};
 use crate::server::api_types::{AgentConfig, ApiResponse};
 use crate::server::auth::{auth_filter, AuthDetails, TokenType};
 use crate::server::messages::Message;
-use crate::server::{Data, HttpError};
+use crate::server::{Data, GithubData, HttpError};
 use failure::Compat;
 use http::{Response, StatusCode};
 use hyper::Body;
@@ -24,10 +24,12 @@ pub struct ExperimentData<T> {
 pub fn routes(
     data: Arc<Data>,
     mutex: Arc<Mutex<Data>>,
+    github_data: Option<Arc<GithubData>>,
 ) -> impl Filter<Extract = (Response<Body>,), Error = Rejection> + Clone {
     let data_cloned = data.clone();
     let data_filter = warp::any().map(move || data_cloned.clone());
     let mutex_filter = warp::any().map(move || mutex.clone());
+    let github_data_filter = warp::any().map(move || github_data.clone());
 
     let config = warp::post2()
         .and(warp::path("config"))
@@ -49,6 +51,7 @@ pub fn routes(
         .and(warp::path("next-experiment"))
         .and(warp::path::end())
         .and(mutex_filter.clone())
+        .and(github_data_filter.clone())
         .and(auth_filter(data.clone(), TokenType::Agent))
         .map(endpoint_next_experiment);
 
@@ -72,6 +75,7 @@ pub fn routes(
         .and(warp::path::end())
         .and(warp::body::json())
         .and(mutex_filter)
+        .and(github_data_filter)
         .and(auth_filter(data, TokenType::Agent))
         .map(endpoint_error);
 
@@ -112,6 +116,7 @@ fn endpoint_config(
 
 fn endpoint_next_experiment(
     mutex: Arc<Mutex<Data>>,
+    github_data: Option<Arc<GithubData>>,
     auth: AuthDetails,
 ) -> Fallible<Response<Body>> {
     //we need to make sure that Experiment::next executes uninterrupted
@@ -119,13 +124,15 @@ fn endpoint_next_experiment(
     let next = Experiment::next(&data.db, &Assignee::Agent(auth.name.clone()))?;
     let result = if let Some((new, ex)) = next {
         if new {
-            if let Some(ref github_issue) = ex.github_issue {
-                Message::new()
-                    .line(
-                        "construction",
-                        format!("Experiment **`{}`** is now **running**", ex.name,),
-                    )
-                    .send(&github_issue.api_url, &data)?;
+            if let Some(github_data) = github_data.as_ref() {
+                if let Some(ref github_issue) = ex.github_issue {
+                    Message::new()
+                        .line(
+                            "construction",
+                            format!("Experiment **`{}`** is now **running**", ex.name,),
+                        )
+                        .send(&github_issue.api_url, &data, github_data)?;
+                }
             }
         }
 
@@ -190,6 +197,7 @@ fn endpoint_heartbeat(data: Arc<Data>, auth: AuthDetails) -> Fallible<Response<B
 fn endpoint_error(
     error: ExperimentData<HashMap<String, String>>,
     mutex: Arc<Mutex<Data>>,
+    github_data: Option<Arc<GithubData>>,
     auth: AuthDetails,
 ) -> Fallible<Response<Body>> {
     let data = mutex.lock().unwrap();
@@ -199,25 +207,27 @@ fn endpoint_error(
     //also set status to failed
     ex.report_failure(&data.db, &Assignee::Agent(auth.name))?;
 
-    if let Some(ref github_issue) = ex.github_issue {
-        Message::new()
-            .line(
-                "rotating_light",
-                format!(
-                    "Experiment **`{}`** has encountered an error: {}",
-                    ex.name,
-                    error.data.get("error").unwrap_or(&String::from("no error")),
-                ),
-            )
-            .line(
-                "hammer_and_wrench",
-                "If the error is fixed use the `retry` command.",
-            )
-            .note(
-                "sos",
-                "Can someone from the infra team check in on this? @rust-lang/infra",
-            )
-            .send(&github_issue.api_url, &data)?;
+    if let Some(github_data) = github_data.as_ref() {
+        if let Some(ref github_issue) = ex.github_issue {
+            Message::new()
+                .line(
+                    "rotating_light",
+                    format!(
+                        "Experiment **`{}`** has encountered an error: {}",
+                        ex.name,
+                        error.data.get("error").unwrap_or(&String::from("no error")),
+                    ),
+                )
+                .line(
+                    "hammer_and_wrench",
+                    "If the error is fixed use the `retry` command.",
+                )
+                .note(
+                    "sos",
+                    "Can someone from the infra team check in on this? @rust-lang/infra",
+                )
+                .send(&github_issue.api_url, &data, &github_data)?;
+        }
     }
     Ok(ApiResponse::Success { result: true }.into_response()?)
 }

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -86,10 +86,10 @@ pub fn run(
                 format!("Automatically detected try build {}", build.merge_sha),
             );
             let pr_head = github_data
-                .github
+                .api
                 .get_pr_head_sha(&repo.full_name, issue.number)?;
             let mut merge_commit = github_data
-                .github
+                .api
                 .get_commit(&repo.full_name, &build.merge_sha)?;
             if merge_commit.parents.len() == 2 {
                 // The first parent is the rust-lang/rust commit, and the second
@@ -275,7 +275,7 @@ pub fn abort(
 }
 
 pub fn reload_acl(data: &Data, github_data: &GithubData, issue: &Issue) -> Fallible<()> {
-    data.acl.refresh_cache(&github_data.github)?;
+    data.acl.refresh_cache(&github_data.api)?;
 
     Message::new()
         .line("hammer_and_wrench", "List of authorized users reloaded!")

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -7,14 +7,14 @@ use crate::server::messages::{Label, Message};
 use crate::server::routes::webhooks::args::{
     AbortArgs, CheckArgs, EditArgs, RetryArgs, RetryReportArgs, RunArgs,
 };
-use crate::server::Data;
+use crate::server::{Data, GithubData};
 use crate::toolchain::Toolchain;
 use rustwide::Toolchain as RustwideToolchain;
 
-pub fn ping(data: &Data, issue: &Issue) -> Fallible<()> {
+pub fn ping(data: &Data, github_data: &GithubData, issue: &Issue) -> Fallible<()> {
     Message::new()
         .line("ping_pong", "**Pong!**")
-        .send(&issue.url, data)?;
+        .send(&issue.url, data, github_data)?;
 
     Ok(())
 }
@@ -22,6 +22,7 @@ pub fn ping(data: &Data, issue: &Issue) -> Fallible<()> {
 pub fn check(
     host: &str,
     data: &Data,
+    github_data: &GithubData,
     repo: &Repository,
     issue: &Issue,
     args: CheckArgs,
@@ -29,6 +30,7 @@ pub fn check(
     run(
         host,
         data,
+        github_data,
         repo,
         issue,
         RunArgs {
@@ -49,6 +51,7 @@ pub fn check(
 pub fn run(
     host: &str,
     data: &Data,
+    github_data: &GithubData,
     repo: &Repository,
     issue: &Issue,
     args: RunArgs,
@@ -82,8 +85,12 @@ pub fn run(
                 "robot",
                 format!("Automatically detected try build {}", build.merge_sha),
             );
-            let pr_head = data.github.get_pr_head_sha(&repo.full_name, issue.number)?;
-            let mut merge_commit = data.github.get_commit(&repo.full_name, &build.merge_sha)?;
+            let pr_head = github_data
+                .github
+                .get_pr_head_sha(&repo.full_name, issue.number)?;
+            let mut merge_commit = github_data
+                .github
+                .get_commit(&repo.full_name, &build.merge_sha)?;
             if merge_commit.parents.len() == 2 {
                 // The first parent is the rust-lang/rust commit, and the second
                 // parent (index 1) is the PR commit
@@ -146,12 +153,12 @@ pub fn run(
                 "You can check out [the queue](https://{}) and [this experiment's details](https://{0}/ex/{1}).", host, name
             ),
         ).set_label(Label::ExperimentQueued)
-        .send(&issue.url, data)?;
+        .send(&issue.url, data,github_data)?;
 
     Ok(())
 }
 
-pub fn edit(data: &Data, issue: &Issue, args: EditArgs) -> Fallible<()> {
+pub fn edit(data: &Data, github_data: &GithubData, issue: &Issue, args: EditArgs) -> Fallible<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
     let crates = args
@@ -178,12 +185,17 @@ pub fn edit(data: &Data, issue: &Issue, args: EditArgs) -> Fallible<()> {
             "memo",
             format!("Configuration of the **`{}`** experiment changed.", name),
         )
-        .send(&issue.url, data)?;
+        .send(&issue.url, data, github_data)?;
 
     Ok(())
 }
 
-pub fn retry_report(data: &Data, issue: &Issue, args: RetryReportArgs) -> Fallible<()> {
+pub fn retry_report(
+    data: &Data,
+    github_data: &GithubData,
+    issue: &Issue,
+    args: RetryReportArgs,
+) -> Fallible<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
     if let Some(mut experiment) = Experiment::get(&data.db, &name)? {
@@ -205,7 +217,7 @@ pub fn retry_report(data: &Data, issue: &Issue, args: RetryReportArgs) -> Fallib
                 format!("Generation of the report for **`{}`** queued again.", name),
             )
             .set_label(Label::ExperimentQueued)
-            .send(&issue.url, data)?;
+            .send(&issue.url, data, github_data)?;
 
         Ok(())
     } else {
@@ -213,7 +225,12 @@ pub fn retry_report(data: &Data, issue: &Issue, args: RetryReportArgs) -> Fallib
     }
 }
 
-pub fn retry(data: &Data, issue: &Issue, args: RetryArgs) -> Fallible<()> {
+pub fn retry(
+    data: &Data,
+    github_data: &GithubData,
+    issue: &Issue,
+    args: RetryArgs,
+) -> Fallible<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
     if let Some(mut experiment) = Experiment::get(&data.db, &name)? {
@@ -230,7 +247,7 @@ pub fn retry(data: &Data, issue: &Issue, args: RetryArgs) -> Fallible<()> {
                 format!("Experiment **`{}`** queued again.", name),
             )
             .set_label(Label::ExperimentQueued)
-            .send(&issue.url, data)?;
+            .send(&issue.url, data, github_data)?;
 
         Ok(())
     } else {
@@ -238,7 +255,12 @@ pub fn retry(data: &Data, issue: &Issue, args: RetryArgs) -> Fallible<()> {
     }
 }
 
-pub fn abort(data: &Data, issue: &Issue, args: AbortArgs) -> Fallible<()> {
+pub fn abort(
+    data: &Data,
+    github_data: &GithubData,
+    issue: &Issue,
+    args: AbortArgs,
+) -> Fallible<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
     actions::DeleteExperiment { name: name.clone() }
@@ -247,17 +269,17 @@ pub fn abort(data: &Data, issue: &Issue, args: AbortArgs) -> Fallible<()> {
     Message::new()
         .line("wastebasket", format!("Experiment **`{}`** deleted!", name))
         .set_label(Label::ExperimentCompleted)
-        .send(&issue.url, data)?;
+        .send(&issue.url, data, github_data)?;
 
     Ok(())
 }
 
-pub fn reload_acl(data: &Data, issue: &Issue) -> Fallible<()> {
-    data.acl.refresh_cache(&data.github)?;
+pub fn reload_acl(data: &Data, github_data: &GithubData, issue: &Issue) -> Fallible<()> {
+    data.acl.refresh_cache(&github_data.github)?;
 
     Message::new()
         .line("hammer_and_wrench", "List of authorized users reloaded!")
-        .send(&issue.url, data)?;
+        .send(&issue.url, data, github_data)?;
 
     Ok(())
 }

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::server::github::{EventIssueComment, Issue, Repository};
 use crate::server::messages::Message;
 use crate::server::routes::webhooks::args::Command;
-use crate::server::Data;
+use crate::server::{Data, GithubData};
 use bytes::buf::Buf;
 use hmac::{Hmac, Mac};
 use http::{HeaderMap, Response, StatusCode};
@@ -20,8 +20,9 @@ fn process_webhook(
     signature: &str,
     event: &str,
     data: &Data,
+    github_data: &GithubData,
 ) -> Fallible<()> {
-    if !verify_signature(&data.tokens.bot.webhooks_secret, payload, signature) {
+    if !verify_signature(&github_data.tokens.webhooks_secret, payload, signature) {
         bail!("invalid signature for the webhook!");
     }
 
@@ -37,7 +38,7 @@ fn process_webhook(
 
             crate::server::try_builds::detect(
                 &data.db,
-                &data.github,
+                &github_data.github,
                 &p.repository.full_name,
                 p.issue.number,
                 &p.comment.body,
@@ -51,6 +52,7 @@ fn process_webhook(
                 &p.repository,
                 &p.issue,
                 data,
+                github_data,
             ) {
                 Message::new()
                     .line("rotating_light", format!("**Error:** {}", e))
@@ -58,7 +60,7 @@ fn process_webhook(
                         "sos",
                         "If you have any trouble with Crater please ping **`@rust-lang/infra`**!",
                     )
-                    .send(&p.issue.url, data)?;
+                    .send(&p.issue.url, data, github_data)?;
             }
         }
         e => bail!("invalid event received: {}", e),
@@ -75,8 +77,9 @@ fn process_command(
     repo: &Repository,
     issue: &Issue,
     data: &Data,
+    github_data: &GithubData,
 ) -> Fallible<()> {
-    let start = format!("@{} ", data.bot_username);
+    let start = format!("@{} ", github_data.bot_username);
     for line in body.lines() {
         if !line.starts_with(&start) {
             continue;
@@ -101,7 +104,7 @@ fn process_command(
                         crate::CRATER_REPO_URL,
                     ),
                 )
-                .send(&issue.url, data)?;
+                .send(&issue.url, data, github_data)?;
             return Ok(());
         }
 
@@ -112,35 +115,35 @@ fn process_command(
 
         match args {
             Command::Ping(_) => {
-                commands::ping(data, issue)?;
+                commands::ping(data, github_data, issue)?;
             }
 
             Command::Run(args) => {
-                commands::run(host, data, repo, issue, args)?;
+                commands::run(host, data, github_data, repo, issue, args)?;
             }
 
             Command::Check(args) => {
-                commands::check(host, data, repo, issue, args)?;
+                commands::check(host, data, github_data, repo, issue, args)?;
             }
 
             Command::Edit(args) => {
-                commands::edit(data, issue, args)?;
+                commands::edit(data, github_data, issue, args)?;
             }
 
             Command::RetryReport(args) => {
-                commands::retry_report(data, issue, args)?;
+                commands::retry_report(data, github_data, issue, args)?;
             }
 
             Command::Retry(args) => {
-                commands::retry(data, issue, args)?;
+                commands::retry(data, github_data, issue, args)?;
             }
 
             Command::Abort(args) => {
-                commands::abort(data, issue, args)?;
+                commands::abort(data, github_data, issue, args)?;
             }
 
             Command::ReloadACL(_) => {
-                commands::reload_acl(data, issue)?;
+                commands::reload_acl(data, github_data, issue)?;
             }
         }
 
@@ -187,7 +190,12 @@ fn verify_signature(secret: &str, payload: &[u8], raw_signature: &str) -> bool {
     mac.verify(&signature).is_ok()
 }
 
-fn receive_endpoint(data: Arc<Data>, headers: HeaderMap, body: FullBody) -> Fallible<()> {
+fn receive_endpoint(
+    data: Arc<Data>,
+    github_data: Arc<GithubData>,
+    headers: HeaderMap,
+    body: FullBody,
+) -> Fallible<()> {
     let signature = headers
         .get("X-Hub-Signature")
         .and_then(|h| h.to_str().ok())
@@ -201,32 +209,40 @@ fn receive_endpoint(data: Arc<Data>, headers: HeaderMap, body: FullBody) -> Fall
         .and_then(|h| h.to_str().ok())
         .ok_or_else(|| err_msg("missing header Host\n"))?;
 
-    process_webhook(body.bytes(), host, signature, event, &data)
+    process_webhook(body.bytes(), host, signature, event, &data, &github_data)
 }
 
 pub fn routes(
     data: Arc<Data>,
+    github_data: Option<Arc<GithubData>>,
 ) -> impl Filter<Extract = (Response<Body>,), Error = Rejection> + Clone {
     let data_filter = warp::any().map(move || data.clone());
+    let github_data_filter = warp::any().and_then(move || match github_data.clone() {
+        Some(github_data) => Ok(github_data),
+        None => Err(warp::reject::not_found()),
+    });
 
     warp::post2()
         .and(warp::path::end())
         .and(data_filter)
+        .and(github_data_filter)
         .and(warp::header::headers_cloned())
         .and(warp::body::concat())
-        .map(|data: Arc<Data>, headers: HeaderMap, body: FullBody| {
-            let mut resp: Response<Body>;
-            match receive_endpoint(data, headers, body) {
-                Ok(()) => resp = Response::new("OK\n".into()),
-                Err(err) => {
-                    error!("error while processing webhook");
-                    crate::utils::report_failure(&err);
+        .map(
+            |data: Arc<Data>, github_data: Arc<GithubData>, headers: HeaderMap, body: FullBody| {
+                let mut resp: Response<Body>;
+                match receive_endpoint(data, github_data, headers, body) {
+                    Ok(()) => resp = Response::new("OK\n".into()),
+                    Err(err) => {
+                        error!("error while processing webhook");
+                        crate::utils::report_failure(&err);
 
-                    resp = Response::new(format!("Error: {}\n", err).into());
-                    *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                        resp = Response::new(format!("Error: {}\n", err).into());
+                        *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                    }
                 }
-            }
 
-            resp
-        })
+                resp
+            },
+        )
 }

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -38,7 +38,7 @@ fn process_webhook(
 
             crate::server::try_builds::detect(
                 &data.db,
-                &github_data.github,
+                &github_data.api,
                 &p.repository.full_name,
                 p.issue.number,
                 &p.comment.body,

--- a/src/server/tokens.rs
+++ b/src/server/tokens.rs
@@ -52,7 +52,8 @@ impl ReportsBucket {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Tokens {
-    pub bot: BotTokens,
+    #[serde(default)]
+    pub bot: Option<BotTokens>,
     pub reports_bucket: ReportsBucket,
     pub agents: HashMap<String, String>,
 }
@@ -61,10 +62,7 @@ pub struct Tokens {
 impl Default for Tokens {
     fn default() -> Self {
         Tokens {
-            bot: BotTokens {
-                webhooks_secret: String::new(),
-                api_token: String::new(),
-            },
+            bot: None,
             reports_bucket: ReportsBucket {
                 region: BucketRegion::S3 {
                     region: "us-west-1".to_string(),


### PR DESCRIPTION
This pr makes the following changes: 
- make `BotTokens` in `Tokens` optional
- move the github specific data in `Data` to a new struct `GithubData`
- add an additional `github_data` parameter to functions that interact with the github api

if no `BotTokens` are supplied:
- the github webhooks will reject with `not_found`
- the server will not send message to github issues