### PR TITLE
Classify network errors as spurious

### DIFF
--- a/src/report/display.rs
+++ b/src/report/display.rs
@@ -12,6 +12,7 @@ impl ResultName for FailureReason {
         match self {
             FailureReason::Unknown => "failed (unknown)".into(),
             FailureReason::Timeout => "timed out".into(),
+            FailureReason::NetworkAccess => "network access".into(),
             FailureReason::OOM => "OOM".into(),
             FailureReason::ICE => "ICE".into(),
             FailureReason::CompilerError(_) => "compiler error".into(),
@@ -23,6 +24,7 @@ impl ResultName for FailureReason {
         match self {
             FailureReason::CompilerError(_) | FailureReason::DependsOn(_) => self.to_string(),
             FailureReason::Unknown
+            | FailureReason::NetworkAccess
             | FailureReason::Timeout
             | FailureReason::OOM
             | FailureReason::ICE => self.short_name(),

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -198,6 +198,7 @@ pub enum FailureReason {
     OOM,
     Timeout,
     ICE,
+    NetworkAccess,
     CompilerError(BTreeSet<DiagnosticCode>),
     DependsOn(BTreeSet<Crate>),
 }
@@ -211,6 +212,7 @@ impl ::std::fmt::Display for FailureReason {
             FailureReason::OOM => write!(f, "oom"),
             FailureReason::Timeout => write!(f, "timeout"),
             FailureReason::ICE => write!(f, "ice"),
+            FailureReason::NetworkAccess => write!(f, "network-access"),
             FailureReason::CompilerError(codes) => write!(
                 f,
                 "compiler-error({})",
@@ -271,7 +273,7 @@ impl ::std::str::FromStr for FailureReason {
 impl FailureReason {
     pub(crate) fn is_spurious(&self) -> bool {
         match *self {
-            FailureReason::OOM | FailureReason::Timeout => true,
+            FailureReason::OOM | FailureReason::Timeout | FailureReason::NetworkAccess => true,
             FailureReason::CompilerError(_)
             | FailureReason::DependsOn(_)
             | FailureReason::Unknown


### PR DESCRIPTION
This adds detection for a particularly common network error message.

Resolves https://github.com/rust-lang/crater/issues/580.