### PR TITLE
Bump libgit2-sys version to be compatible with systems that have newer libgit2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,9 +1028,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "git2"
-version = "0.13.12"
+version = "0.13.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
 dependencies = [
  "bitflags",
  "libc",
@@ -1481,9 +1481,9 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.14+1.1.0"
+version = "0.12.26+1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
`cargo run -- prepare-local` doesn't work at the moment on Arch/Manjaro, because rolling release distros are shipping `libgit` 1.3.0, which has a compatability break (intentional or not it's unclear) since 1.1.0. `libgit2-sys` will build a vendored version if the system version is too old, but not if it is too new. So with this change, the build should be correct on all systems.

~~I'm running into the same error as https://github.com/rustsec/rustsec/issues/431 and applying the fix suggested therein.~~