### PR TITLE
Add a CPU limit, raise example memory limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "env_logger",
  "failure",
  "flate2",
+ "git2",
  "hmac 0.7.1",
  "http 0.1.21",
  "hyper 0.12.35",
@@ -1028,9 +1029,9 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "git2"
-version = "0.13.12"
+version = "0.13.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
 dependencies = [
  "bitflags",
  "libc",
@@ -1481,9 +1482,9 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.14+1.1.0"
+version = "0.12.26+1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ ctrlc = "3.1.3"
 prometheus = "0.7.0"
 cargo_metadata = "0.12.1"
 indexmap = "1.4.0"
+git2 = { version = "0.13", features = ["vendored-libgit2"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.2"

--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,8 @@ local-crates = []
 
 [sandbox]
 # Maximum amount of RAM allowed during builds
-memory-limit = "1536M"  # 1.5G
+memory-limit = "4096M"  # 4G, 1G/cpu
+cpu-limit = 4
 # Restrictions on the amount of information stored in build logs
 build-log-max-size = "5M"
 build-log-max-lines = 10000

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,7 @@ pub struct DemoCrates {
 #[serde(rename_all = "kebab-case")]
 pub struct SandboxConfig {
     pub memory_limit: Size,
+    pub cpu_limit: u16,
     pub build_log_max_size: Size,
     pub build_log_max_lines: usize,
 }
@@ -256,6 +257,7 @@ impl Default for Config {
             local_crates: HashMap::new(),
             sandbox: SandboxConfig {
                 memory_limit: Size::Gigabytes(2),
+                cpu_limit: 1,
                 build_log_max_size: Size::Megabytes(1),
                 build_log_max_lines: 1000,
             },
@@ -308,6 +310,7 @@ mod tests {
             "local-crates = []\n",
             "[sandbox]\n",
             "memory-limit = \"2G\"\n",
+            "cpu-limit = 1\n",
             "build-log-max-size = \"2M\"\n",
             "build-log-max-lines = 1000\n",
             "[crates]\n",

--- a/tests/check_config/bad-duplicate-crate.toml
+++ b/tests/check_config/bad-duplicate-crate.toml
@@ -17,6 +17,7 @@ local-crates = []
 
 [sandbox]
 memory-limit = "1536M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/check_config/bad-missing-crate.toml
+++ b/tests/check_config/bad-missing-crate.toml
@@ -17,6 +17,7 @@ local-crates = []
 
 [sandbox]
 memory-limit = "1536M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/check_config/bad-missing-repo.toml
+++ b/tests/check_config/bad-missing-repo.toml
@@ -17,6 +17,7 @@ local-crates = []
 
 [sandbox]
 memory-limit = "1536M"
+cpu-limit= 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/check_config/good.toml
+++ b/tests/check_config/good.toml
@@ -17,6 +17,7 @@ local-crates = []
 
 [sandbox]
 memory-limit = "1536M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/minicrater/blacklist/config.toml
+++ b/tests/minicrater/blacklist/config.toml
@@ -18,6 +18,7 @@ local-crates = ["build-pass", "build-fail", "test-fail"]
 
 [sandbox]
 memory-limit = "512M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/minicrater/clippy/config.toml
+++ b/tests/minicrater/clippy/config.toml
@@ -17,6 +17,7 @@ local-crates = ["build-pass", "clippy-warn"]
 
 [sandbox]
 memory-limit = "512M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/minicrater/full/config.toml
+++ b/tests/minicrater/full/config.toml
@@ -17,6 +17,7 @@ local-crates = []
 
 [sandbox]
 memory-limit = "512M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/minicrater/ignore-blacklist/config.toml
+++ b/tests/minicrater/ignore-blacklist/config.toml
@@ -17,6 +17,7 @@ local-crates = ["build-pass", "build-fail", "test-fail"]
 
 [sandbox]
 memory-limit = "512M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/minicrater/missing-repo/config.toml
+++ b/tests/minicrater/missing-repo/config.toml
@@ -17,6 +17,7 @@ local-crates = []
 
 [sandbox]
 memory-limit = "512M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/minicrater/resource-exhaustion/config.toml
+++ b/tests/minicrater/resource-exhaustion/config.toml
@@ -17,6 +17,7 @@ local-crates = ["build-pass", "memory-hungry"]
 
 [sandbox]
 memory-limit = "512M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 

--- a/tests/minicrater/small/config.toml
+++ b/tests/minicrater/small/config.toml
@@ -17,6 +17,7 @@ local-crates = ["build-pass", "beta-regression"]
 
 [sandbox]
 memory-limit = "512M"
+cpu-limit = 1
 build-log-max-size = "2M"
 build-log-max-lines = 1000
 


### PR DESCRIPTION
Part of addressing https://github.com/rust-lang/crater/issues/589

In short, the combination of no job limit and a low memory limit has been causing a lot of OOMs in crater runs. This adds a job limit and enforces it including for doctests, which are built by the test runner. If nothing else, setting this CPU limit provides reproducible OOMs because many crates have peak memory usage proportional to build parallelism.

I have locally verified that a limit of 4 GB is sufficient to build all tests in the top 1,000. Just the CPU limit alone fixes the majority if the OOMs, but 10 of the top 1,000 crates have a very memory-hungry link step that breaks past 1.5 GB no matter what other configuration is applied.

This PR contains https://github.com/rust-lang/crater/pull/598, I'll rebase it up after that is resolved.