### PR TITLE
Optimize run_by query to avoid full scan of experiment_crates table

### DIFF
--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -282,11 +282,11 @@ impl Experiment {
 
     pub fn run_by(db: &Database, assignee: &Assignee) -> Fallible<Option<Experiment>> {
         let record = db.get_row(
-            "SELECT * FROM experiments \
-             INNER JOIN experiment_crates ON experiment_crates.experiment \
-             = experiments.name WHERE experiment_crates.assigned_to = ?1 \
-             AND experiment_crates.status = ?2 AND experiments.status = ?2 \
-             AND experiment_crates.skipped = 0 LIMIT 1",
+            "select * from experiments where name in ( \
+                select experiment from experiment_crates \
+                    where status = ?2 and skipped = 0 and assigned_to = ?1 and \
+                    experiment in (select name from experiments where status = ?2)) \
+            limit 1",
             &[&assignee.to_string(), Status::Running.to_str()],
             |r| ExperimentDBRecord::from_row(r),
         )?;


### PR DESCRIPTION
The query plan was previously:

    QUERY PLAN
    |--SCAN TABLE experiment_crates
    `--SEARCH TABLE experiments USING INDEX sqlite_autoindex_experiments_1 (name=?)

and now is:

    QUERY PLAN
    |--SEARCH TABLE experiments USING INDEX sqlite_autoindex_experiments_1 (name=?)
    `--LIST SUBQUERY 2
    |--SEARCH TABLE experiment_crates USING INDEX experiment_crates__experiment_skipped (experiment=? AND skipped=?)
    `--LIST SUBQUERY 1
        `--SCAN TABLE experiments

While the new query does search more, it does so in a way that is significantly
more efficient, as it can avoid scanning the whole experiment_crates table
(which is quite large).