### PR TITLE
Recover gracefully from agent failure

### DIFF
--- a/src/report/analyzer.rs
+++ b/src/report/analyzer.rs
@@ -40,7 +40,7 @@ fn analyze_detailed(toolchain: usize, crates: Vec<CrateResult>) -> ReportCrates 
     let mut root = Vec::new();
     for krate in crates {
         if let BuildFail(FailureReason::DependsOn(ref deps)) =
-            (&krate.runs[toolchain]).as_ref().unwrap().res
+            krate.runs[toolchain].as_ref().unwrap().res
         {
             for dep in deps {
                 tree.entry(dep.clone())

--- a/src/report/markdown.rs
+++ b/src/report/markdown.rs
@@ -31,7 +31,7 @@ struct ResultsContext<'a> {
 }
 
 fn write_crate(
-    mut rendered: &mut String,
+    rendered: &mut String,
     krate: &CrateResult,
     comparison: Comparison,
     is_child: bool,
@@ -76,7 +76,7 @@ fn write_crate(
         };
 
         writeln!(
-            &mut rendered,
+            rendered,
             "{}[{}{}]({}) {} {} **{}** [start]({}/log.txt) | [end]({}/log.txt)",
             prefix,
             krate.name,
@@ -90,7 +90,7 @@ fn write_crate(
         )?;
     } else {
         writeln!(
-            &mut rendered,
+            rendered,
             "{}[{}{}]({}) {} [start]({}/log.txt) | [end]({}/log.txt)",
             prefix, krate.name, status_warning, krate.url, comparison, runs[1], runs[3]
         )?;
@@ -103,10 +103,10 @@ fn render_markdown(context: &ResultsContext) -> Fallible<String> {
     let mut rendered = String::new();
 
     //add title
-    writeln!(&mut rendered, "# Crater report for {}\n\n", context.ex.name)?;
+    writeln!(rendered, "# Crater report for {}\n\n", context.ex.name)?;
 
     for (comparison, results) in context.categories.iter() {
-        writeln!(&mut rendered, "\n### {}", comparison)?;
+        writeln!(rendered, "\n### {}", comparison)?;
         match results {
             ReportCratesMD::Plain(crates) => {
                 for krate in crates {
@@ -123,7 +123,7 @@ fn render_markdown(context: &ResultsContext) -> Fallible<String> {
 
                 for (krate, deps) in orphans {
                     writeln!(
-                        &mut rendered,
+                        rendered,
                         "* [{}]({}) (not covered in crater testing)",
                         krate,
                         crate_to_url(krate)

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -209,7 +209,7 @@ fn endpoint_error(
     let mut ex = Experiment::get(&data.db, &error.experiment_name)?
         .ok_or_else(|| err_msg("no experiment run by this agent"))?;
 
-    //also set status to failed
+    data.metrics.record_error(&auth.name, &ex.name);
     ex.handle_failure(&data.db, &Assignee::Agent(auth.name))?;
 
     Ok(ApiResponse::Success { result: true }.into_response()?)

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -51,7 +51,7 @@ pub fn routes(
         .and(warp::path("next-experiment"))
         .and(warp::path::end())
         .and(mutex_filter.clone())
-        .and(github_data_filter.clone())
+        .and(github_data_filter)
         .and(auth_filter(data.clone(), TokenType::Agent))
         .map(endpoint_next_experiment);
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -118,7 +118,7 @@ impl FromStr for Toolchain {
         for part in parts {
             if let Some(equal_idx) = part.find('=') {
                 let (flag, value_with_equal) = part.split_at(equal_idx);
-                let value = (&value_with_equal[1..]).to_string();
+                let value = value_with_equal[1..].to_string();
 
                 if value.is_empty() {
                     return Err(ToolchainParseError::InvalidFlag(flag.to_string()));


### PR DESCRIPTION
Previously, any agent reporting an error would cause an experiment to come to a
hard stop. This is noisy (leads to a user-visible report) and, at least lately,
not actually representative of a terminal failure. Instead, we take the approach
of re-queueing any crates assigned to that agent and logging an error on the
server host specifying which agent failed.

As the error message is now not typically posted publicly (and no longer needs
to be short for being in a GitHub comment), we will also have more opportunity
to add extra metadata over time to that message (in future PRs) enabling
diagnosing and fixing these errors.

In the future, we will likely also want some tracking/reporting of these
failures such that hard errors across all agents lead to alerting the infra
team, but this may be best done through Prometheus metrics rather than GitHub
"end-user" visible comments (which are likely not the best way to reach infra
team members regardless).

r? @pietroalbini 