### PR TITLE
Stop logging experiment progress

### DIFF
--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -163,11 +163,6 @@ fn endpoint_record_progress(
     let mut ex = Experiment::get(&data.db, &result.experiment_name)?
         .ok_or_else(|| err_msg("no experiment run by this agent"))?;
 
-    info!(
-        "received progress on experiment {} from agent {}",
-        ex.name, auth.name,
-    );
-
     data.metrics
         .record_completed_jobs(&auth.name, &ex.name, result.data.results.len() as i64);
 


### PR DESCRIPTION
These messages arrive at ~1-2 ops/sec on average, and are largely noise: their
*absence* may be notable, but not more than that. Our Prometheus metrics are
largely equivalent regardless. These messages also may mask more important
logging which is actually practically useful.

cc https://github.com/rust-lang/crater/pull/602#issuecomment-1027925325

r? @pietroalbini 