### PR TITLE
Discover necessity of reporting in the background

### DIFF
--- a/src/server/reports.rs
+++ b/src/server/reports.rs
@@ -37,7 +37,7 @@ fn reports_thread(data: &Data, github_data: Option<&GithubData>) -> Fallible<()>
     let results = DatabaseDB::new(&data.db);
 
     loop {
-        let mut ex = match Experiment::first_by_status(&data.db, Status::NeedsReport)? {
+        let mut ex = match Experiment::ready_for_report(&data.db)? {
             Some(ex) => ex,
             None => {
                 // This will sleep AUTOMATIC_THREAD_WAKEUP seconds *or* until a wake is received


### PR DESCRIPTION
This will increase the latency to starting a report by ~10 minutes in the worst case, but those take long enough to generate (and experiments are slow enough) that this doesn't seem like a big deal. In practice, my hope is that it will:

* Avoid needing retry-report quite as frequently, as OOMs and other abnormal crashes will be gracefully recovered from (albeit likely sending the server into a death spiral if we *really* can't generate the report; in practice this shouldn't happen). It was already somewhat the case that a server restart would start the generation again, just that a thread *panic* didn't since the report generation thread died in that case. So this should be essentially as-before.
* Avoid fairly heavy piece of work done on *every* new result, which hopefully improved result endpoint performance and reduces normal server load.

See also commit messages for some additional details.

