### PR TITLE
Store logs uncompressed in db

### DIFF
--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -168,7 +168,7 @@ fn endpoint_record_progress(
         .record_completed_jobs(&auth.name, &ex.name, result.data.results.len() as i64);
 
     let db = DatabaseDB::new(&data.db);
-    db.store(&ex, &result.data, EncodingType::Gzip)?;
+    db.store(&ex, &result.data, EncodingType::Plain)?;
 
     let ret = Ok(ApiResponse::Success { result: true }.into_response()?);
     data.metrics


### PR DESCRIPTION
This will mean that the database grows faster -- and we do more disk I/O -- but
currently at least disk is likely easier for us to grow than the single thread
handling of incoming results.

(Will look at production performance to decide whether to keep or revert this change).