### PR TITLE
Wait for up to a second for existing database lock to clear

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -19,6 +19,7 @@ struct ConnectionCustomizer;
 impl CustomizeConnection<Connection, ::rusqlite::Error> for ConnectionCustomizer {
     fn on_acquire(&self, conn: &mut Connection) -> Result<(), ::rusqlite::Error> {
         conn.execute("PRAGMA foreign_keys = ON;", [])?;
+        conn.execute("PRAGMA busy_timeout = 1000;", [])?;
         Ok(())
     }
 }


### PR DESCRIPTION
This lets users queue new builds and otherwise schedule work while an ongoing
run is proceeding (with lots of record-progress hits). Arguably we want to
prioritize user-initiated commands to take effect and cancel ongoing
record-progress operations (and other automated work), but that will need more
care.

Should fix cases like https://github.com/rust-lang/rust/pull/94775#issuecomment-1064223941,
or at least make them much more rare (individual database operations should very rarely take >1s,
though our logs do suggest it is not entirely infrequent today. (That's something that's worth looking into,
just haven't had time yet).

```
[2022-03-10T16:08:38Z DEBUG crater::db] sql query "INSERT INTO results (experiment, crate, toolchain, result, log, encoding) VALUES (?1, ?2, ?3, ?4, ?5, ?6);" executed in 5.009915144s
[2022-03-10T16:08:43Z DEBUG crater::db] sql query "INSERT INTO results (experiment, crate, toolchain, result, log, encoding) VALUES (?1, ?2, ?3, ?4, ?5, ?6);" executed in 5.009725792s
[2022-03-10T16:08:46Z DEBUG crater::db] sql query "INSERT INTO results (experiment, crate, toolchain, result, log, encoding) VALUES (?1, ?2, ?3, ?4, ?5, ?6);" executed in 3.235525973s
```