### PR TITLE
Move record-progress processing to separate thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "crates-index",
+ "crossbeam-channel",
  "crossbeam-utils 0.5.0",
  "csv",
  "ctrlc",
@@ -906,18 +907,18 @@ checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-cpupool"
@@ -931,17 +932,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2 1.0.36",
  "quote 1.0.7",
  "syn 1.0.85",
@@ -949,34 +949,29 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
-dependencies = [
- "once_cell",
-]
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1085,7 +1080,7 @@ dependencies = [
  "http 0.2.1",
  "indexmap",
  "slab",
- "tokio 1.1.0",
+ "tokio 1.16.1",
  "tokio-util",
  "tracing",
 ]
@@ -1322,7 +1317,7 @@ dependencies = [
  "itoa",
  "pin-project",
  "socket2 0.4.2",
- "tokio 1.1.0",
+ "tokio 1.16.1",
  "tower-service",
  "tracing",
  "want 0.3.0",
@@ -1350,7 +1345,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper 0.14.8",
  "native-tls",
- "tokio 1.1.0",
+ "tokio 1.16.1",
  "tokio-native-tls",
 ]
 
@@ -2104,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -2154,18 +2149,6 @@ dependencies = [
  "predicates-core",
  "treeline",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -2564,7 +2547,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
- "tokio 1.1.0",
+ "tokio 1.16.1",
  "tokio-native-tls",
  "url 2.2.0",
  "wasm-bindgen",
@@ -2705,7 +2688,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "tokio 1.1.0",
+ "tokio 1.16.1",
  "tokio-stream",
  "toml 0.5.7",
  "walkdir",
@@ -3253,11 +3236,10 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.1.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efab2086f17abcddb8f756117665c958feee6b2e39974c2f1600592ab3a4195"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
- "autocfg 1.0.1",
  "bytes 1.0.1",
  "libc",
  "memchr",
@@ -3340,7 +3322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.1.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -3370,7 +3352,7 @@ checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio 1.1.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -3470,7 +3452,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite",
- "tokio 1.1.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4", features = ["serde"] }
 chrono-humanize = "0.1.1"
 crates-index = "0.16.2"
 crossbeam-utils = "0.5"
+crossbeam-channel = "0.5"
 csv = "1.0.2"
 dotenv = "0.13"
 failure = "0.1.3"

--- a/src/server/api_types.rs
+++ b/src/server/api_types.rs
@@ -20,6 +20,7 @@ pub struct AgentConfig {
 #[serde(tag = "status", rename_all = "kebab-case")]
 pub enum ApiResponse<T> {
     Success { result: T },
+    SlowDown,
     InternalError { error: String },
     Unauthorized,
     NotFound,
@@ -41,8 +42,9 @@ impl ApiResponse<()> {
 
 impl<T> ApiResponse<T> {
     fn status_code(&self) -> StatusCode {
-        match *self {
+        match self {
             ApiResponse::Success { .. } => StatusCode::OK,
+            ApiResponse::SlowDown => StatusCode::TOO_MANY_REQUESTS,
             ApiResponse::InternalError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ApiResponse::Unauthorized => StatusCode::UNAUTHORIZED,
             ApiResponse::NotFound => StatusCode::NOT_FOUND,

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -5,8 +5,8 @@ use crate::server::agents::Agent;
 use chrono::{DateTime, Utc};
 use prometheus::proto::{Metric, MetricFamily};
 use prometheus::{
-    HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, __register_counter_vec, __register_gauge,
-    __register_gauge_vec,
+    HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, __register_counter_vec,
+    __register_gauge, __register_gauge_vec, opts, register_counter, register_int_counter,
 };
 
 const JOBS_METRIC: &str = "crater_completed_jobs_total";
@@ -18,6 +18,7 @@ const ENDPOINT_TIME: &str = "crater_endpoint_time_seconds";
 #[derive(Clone)]
 pub struct Metrics {
     crater_completed_jobs_total: IntCounterVec,
+    pub crater_bounced_record_progress: IntCounter,
     crater_agent_failure: IntCounterVec,
     crater_work_status: IntGaugeVec,
     crater_last_crates_update: IntGauge,
@@ -29,6 +30,10 @@ impl Metrics {
         let jobs_opts = prometheus::opts!(JOBS_METRIC, "total completed jobs");
         let crater_completed_jobs_total =
             prometheus::register_int_counter_vec!(jobs_opts, &["agent", "experiment"])?;
+        let crater_bounced_record_progress = prometheus::register_int_counter!(
+            "crater_bounced_record_progress",
+            "hits with full record progress queue"
+        )?;
         let failure_opts = prometheus::opts!(AGENT_FAILED, "total completed jobs");
         let crater_agent_failure =
             prometheus::register_int_counter_vec!(failure_opts, &["agent", "experiment"])?;
@@ -47,6 +52,7 @@ impl Metrics {
 
         Ok(Metrics {
             crater_completed_jobs_total,
+            crater_bounced_record_progress,
             crater_agent_failure,
             crater_work_status,
             crater_last_crates_update,


### PR DESCRIPTION
This is intended to let us prioritize work on other requests over work on
record-progress, thereby avoiding some of the timeouts and "database is locked"
errors we would otherwise see when the record-progress requests happen to take
priority.

This separate thread is designed to only run when the server has no requests
in-flight (other than a short, bounded, queue of record-progress requests). If
that queue fills up, we will tell workers to slow down, causing them to retry
requests -- currently at fixed intervals and per worker thread, but a future
commit might clean that up a little to have a more intentional delay.

In general this should, hopefully, decrease the error rate as particularly
human-initiated requests should never have to wait for more than one
record-progress event to complete before having largely uncontended access to the
database. (Other requests still happen concurrently, but requests are typically
very rare in comparison to record-progress which are multiple times a second,
effectively constantly processing).

Errors like https://github.com/rust-lang/rust/pull/94775#issuecomment-1064223941 are the primary motivation here, which I hope this is enough to largely clear up.