### PR TITLE
Humanize to hours at most

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,15 +346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-humanize"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a4c32145b4db85fe1c4f2b125a4f9493769df424f5f84baf6b04ea8eaf33c9"
-dependencies = [
- "chrono",
-]
-
-[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,7 +409,6 @@ dependencies = [
  "bytes 0.4.12",
  "cargo_metadata",
  "chrono",
- "chrono-humanize",
  "crates-index",
  "crossbeam-channel",
  "crossbeam-utils 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ opt-level = 0
 base64 = "0.13.0"
 bytes = "0.4.9"
 chrono = { version = "0.4", features = ["serde"] }
-chrono-humanize = "0.1.1"
 crates-index = "0.16.2"
 crossbeam-utils = "0.5"
 crossbeam-channel = "0.5"

--- a/src/crates/lists.rs
+++ b/src/crates/lists.rs
@@ -88,7 +88,7 @@ pub(crate) fn get_crates(
             all_crates.append(&mut GitHubList::get(db)?);
             all_crates.append(&mut LocalList::get(db)?);
 
-            for krate in all_crates.drain(..) {
+            for krate in all_crates {
                 let add = match krate {
                     Crate::Registry(RegistryCrate { ref name, .. }) => demo_registry.remove(name),
                     Crate::GitHub(ref repo) => demo_github.remove(&repo.slug()),

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -155,11 +155,11 @@ impl TasksGraph {
 
         // Try to check for the dependencies of this node
         // The list is collected to make the borrowchecker happy
-        let mut neighbors = self.graph.neighbors(node).collect::<Vec<_>>();
+        let neighbors = self.graph.neighbors(node).collect::<Vec<_>>();
         log::trace!("{} | {:?}: neighbors: {:?}", worker, node, neighbors);
 
         let mut blocked = false;
-        for neighbor in neighbors.drain(..) {
+        for neighbor in neighbors {
             match self.walk_graph(neighbor, ex, db, worker) {
                 WalkResult::Task(id, task) => return WalkResult::Task(id, task),
                 WalkResult::Finished => return WalkResult::Finished,
@@ -219,12 +219,12 @@ impl TasksGraph {
         result: &TestResult,
         worker: &str,
     ) -> Fallible<()> {
-        let mut children = self
+        let children = self
             .graph
             .neighbors_directed(node, Direction::Incoming)
             .collect::<Vec<_>>();
         let mut last_err = None;
-        for child in children.drain(..) {
+        for child in children {
             // Don't recursively mark a child as failed if this is not the only parent of the child
             let parents = self
                 .graph

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -157,7 +157,7 @@ pub fn run_ex<DB: WriteResults + Sync>(
                     Ok(())
                 })?;
 
-        let clean_exit = join_threads(threads.drain(..));
+        let clean_exit = join_threads(threads.into_iter());
         disk_watcher.stop();
         let disk_watcher_clean_exit = join_threads(std::iter::once(disk_watcher_thread));
 


### PR DESCRIPTION
Days are typically fairly non-granular, and most of our runtimes are roughly in
the 48 hour-ish window. Hours should give a much better picture of when to
expect results.

This also drops a dependency in favor of manually humanizing the time.