### PR TITLE
Drop stub needs_exec

### DIFF
--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -137,22 +137,6 @@ impl TasksGraph {
             node,
             self.graph[node]
         );
-        // Ensure tasks are only executed if needed
-        let mut already_executed = false;
-        if let Node::Task {
-            ref task,
-            running: None,
-        } = self.graph[node]
-        {
-            if !task.needs_exec(ex, db) {
-                already_executed = true;
-            }
-        }
-        if already_executed {
-            self.mark_as_completed(node);
-            return WalkResult::NotBlocked;
-        }
-
         // Try to check for the dependencies of this node
         // The list is collected to make the borrowchecker happy
         let neighbors = self.graph.neighbors(node).collect::<Vec<_>>();

--- a/src/runner/tasks.rs
+++ b/src/runner/tasks.rs
@@ -97,28 +97,6 @@ impl fmt::Debug for Task {
 }
 
 impl Task {
-    pub(super) fn needs_exec<DB: WriteResults>(&self, ex: &Experiment, db: &DB) -> bool {
-        // If an error happens while checking if the task should be executed, the error is ignored
-        // and the function returns true.
-        match self.step {
-            TaskStep::Cleanup => true,
-            // The prepare step should always be executed.
-            // It will not be executed if all the dependent tasks are already executed, since the
-            // runner will not reach the prepare task in that case.
-            TaskStep::Prepare => true,
-            // Build tasks should only be executed if there are no results for them
-            TaskStep::Skip { ref tc }
-            | TaskStep::BuildAndTest { ref tc, .. }
-            | TaskStep::BuildOnly { ref tc, .. }
-            | TaskStep::CheckOnly { ref tc, .. }
-            | TaskStep::Clippy { ref tc, .. }
-            | TaskStep::Rustdoc { ref tc, .. }
-            | TaskStep::UnstableFeatures { ref tc } => {
-                db.get_result(ex, tc, &self.krate).unwrap_or(None).is_none()
-            }
-        }
-    }
-
     pub(super) fn mark_as_failed<DB: WriteResults>(
         &self,
         ex: &Experiment,


### PR DESCRIPTION
Runners did not keep track of any state (or support querying upstream) for
completion; we expect individual tasks to only be sent to runners if they should
attempt to run them, and if duplicate work is done that's OK (each individual
task is cheap).

This function already always returned 'true' so just delete it and propagate the
effects of that.