### PR TITLE
Remove dump-tasks-graph

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -307,17 +307,6 @@ pub enum Crater {
     },
 
     #[structopt(
-        name = "dump-tasks-graph",
-        about = "dump the internal tasks graph in .dot format"
-    )]
-    DumpTasksGraph {
-        #[structopt(name = "dest", parse(from_os_str))]
-        dest: PathBuf,
-        #[structopt(name = "experiment", long = "ex", default_value = "default")]
-        ex: Ex,
-    },
-
-    #[structopt(
         name = "check-config",
         about = "check if the config.toml file is valid"
     )]
@@ -627,16 +616,6 @@ impl Crater {
                     &self
                         .workspace(docker_env.as_ref().map(|s| s.as_str()), fast_workspace_init)?,
                 )?;
-            }
-            Crater::DumpTasksGraph { ref dest, ref ex } => {
-                let config = Config::load()?;
-                let db = Database::open()?;
-
-                if let Some(experiment) = Experiment::get(&db, &ex.0)? {
-                    runner::dump_dot(&experiment, &experiment.get_crates(&db)?, &config, dest)?;
-                } else {
-                    bail!("missing experiment: {}", ex.0);
-                }
             }
             Crater::CheckConfig { ref filename } => {
                 if let Err(ref e) = Config::check(filename) {

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -25,7 +25,7 @@ use crate::runner::{
     tasks::{Task, TaskStep},
     RunnerState,
 };
-use petgraph::{dot::Dot, graph::NodeIndex, stable_graph::StableDiGraph, Direction};
+use petgraph::{graph::NodeIndex, stable_graph::StableDiGraph, Direction};
 use std::fmt::{self, Debug};
 use std::sync::Arc;
 
@@ -262,10 +262,6 @@ impl TasksGraph {
 
     pub(super) fn pending_crates_count(&self) -> usize {
         self.graph.neighbors(self.root).count()
-    }
-
-    pub(super) fn generate_dot<'a>(&'a self) -> Dot<&'a StableDiGraph<impl Debug, ()>> {
-        Dot::new(&self.graph)
     }
 }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -15,7 +15,6 @@ use crossbeam_utils::thread::{scope, ScopedJoinHandle};
 use rustwide::logging::LogStorage;
 use rustwide::Workspace;
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 
@@ -195,16 +194,4 @@ where
         }
     }
     clean_exit
-}
-
-pub fn dump_dot(ex: &Experiment, crates: &[Crate], config: &Config, dest: &Path) -> Fallible<()> {
-    info!("computing the tasks graph...");
-    let graph = build_graph(ex, crates, config);
-
-    info!("dumping the tasks graph...");
-    ::std::fs::write(dest, format!("{:?}", graph.generate_dot()).as_bytes())?;
-
-    info!("tasks graph available in {}", dest.to_string_lossy());
-
-    Ok(())
 }


### PR DESCRIPTION
This isn't being used and will likely hurt the ability to refactor the task
graph away from being an actual graph.