### PR TITLE
Add cargoflags to toolchain configuration

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -149,6 +149,8 @@ You can specify a toolchain using a rustup name or `branch#sha`, and use the
 following flags:
 * `+rustflags={flags}`: sets the `RUSTFLAGS` environment variable to `{flags}` when
   building with this toolchain, e.g. `+rustflags=-Zverbose`
+* `+cargoflags={flags}`: appends the given `{flags}` to the Cargo command specified
+  by the experiment mode, e.g. `+cargoflags=-Zavoid-dev-deps`
 * `+patch={crate_name}={git_repo_url}={branch}`: patches all crates built by
   this toolchain to resolve the given crate from the given git repository and branch.
 

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -84,6 +84,11 @@ fn run_cargo<DB: WriteResults>(
     check_errors: bool,
     local_packages_id: &HashSet<PackageId>,
 ) -> Fallible<()> {
+    let mut args = args.to_vec();
+    if let Some(ref tc_cargoflags) = ctx.toolchain.cargoflags {
+        args.extend(tc_cargoflags.split(' '));
+    }
+
     let mut rustflags = format!("--cap-lints={}", ctx.experiment.cap_lints.to_str());
     if let Some(ref tc_rustflags) = ctx.toolchain.rustflags {
         rustflags.push(' ');
@@ -158,7 +163,7 @@ fn run_cargo<DB: WriteResults>(
 
     let mut command = build_env
         .cargo()
-        .args(args)
+        .args(&args)
         .env("CARGO_INCREMENTAL", "0")
         .env("RUST_BACKTRACE", "full")
         .env(rustflags_env, rustflags);

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -72,12 +72,14 @@ pub fn run(
             detected_start = Some(Toolchain {
                 source: RustwideToolchain::ci(&build.base_sha, false),
                 rustflags: None,
+                cargoflags: None,
                 ci_try: false,
                 patches: Vec::new(),
             });
             detected_end = Some(Toolchain {
                 source: RustwideToolchain::ci(&build.merge_sha, false),
                 rustflags: None,
+                cargoflags: None,
                 ci_try: true,
                 patches: Vec::new(),
             });


### PR DESCRIPTION
I am trying to test the new [scrape examples](https://github.com/rust-lang/rust/issues/88791) feature using Crater. Because it's gated behind a Cargo flag `-Zrustdoc-scrape-examples`, I added the ability for Crater to take as input a new `+cargoflags=...` configuration for toolchains, similar to how `+rustflags` works.
 
One possible implementation issue: I'm doing `cargoflags.split(' ')` to split up the provided flags so as to pass them into the command builder. A more robust method would be to use a crate like [shlex](https://docs.rs/shlex/latest/shlex/). I'm not sure if this is important enough to add the dependency, or if there's a better way to do this.