### PR TITLE
Autoremove results from completed experiments

### DIFF
--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -17,8 +17,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::AsRef;
 use std::fmt::{self, Display};
-use std::fs::{self, File};
-use std::io::{self, Read};
+use std::fs;
 use std::path::{Path, PathBuf};
 
 mod analyzer;
@@ -524,7 +523,6 @@ pub trait ReportWriter {
         encoding_type: EncodingType,
     ) -> Fallible<()>;
     fn write_string<P: AsRef<Path>>(&self, path: P, s: Cow<str>, mime: &Mime) -> Fallible<()>;
-    fn copy<P: AsRef<Path>, R: Read>(&self, r: &mut R, path: P, mime: &Mime) -> Fallible<()>;
 }
 
 pub struct FileWriter(PathBuf);
@@ -568,12 +566,6 @@ impl ReportWriter for FileWriter {
     fn write_string<P: AsRef<Path>>(&self, path: P, s: Cow<str>, _: &Mime) -> Fallible<()> {
         self.create_prefix(path.as_ref())?;
         fs::write(&self.0.join(path.as_ref()), s.as_ref().as_bytes())?;
-        Ok(())
-    }
-
-    fn copy<P: AsRef<Path>, R: Read>(&self, r: &mut R, path: P, _: &Mime) -> Fallible<()> {
-        self.create_prefix(path.as_ref())?;
-        io::copy(r, &mut File::create(self.0.join(path.as_ref()))?)?;
         Ok(())
     }
 }
@@ -634,16 +626,6 @@ impl ReportWriter for DummyWriter {
             (path.as_ref().to_path_buf(), mime.clone()),
             s.bytes().collect(),
         );
-        Ok(())
-    }
-
-    fn copy<P: AsRef<Path>, R: Read>(&self, r: &mut R, path: P, mime: &Mime) -> Fallible<()> {
-        let mut buffer = Vec::new();
-        r.read_to_end(&mut buffer)?;
-
-        self.results
-            .borrow_mut()
-            .insert((path.as_ref().to_path_buf(), mime.clone()), buffer);
         Ok(())
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -263,7 +263,7 @@ pub fn generate_report<DB: ReadResults>(
     Ok(RawTestResults { crates: res })
 }
 
-const PROGRESS_FRACTION: usize = 10; // write progress every ~1/N crates
+const PROGRESS_FRACTION: usize = 50; // write progress every ~1/N crates
 
 fn write_logs<DB: ReadResults, W: ReportWriter>(
     db: &DB,

--- a/src/report/s3.rs
+++ b/src/report/s3.rs
@@ -5,7 +5,6 @@ use mime::Mime;
 use rusoto_s3::{PutObjectRequest, S3Client, S3};
 use std::borrow::Cow;
 use std::fmt::{self, Display};
-use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::thread;
@@ -158,12 +157,6 @@ impl ReportWriter for S3Writer {
 
     fn write_string<P: AsRef<Path>>(&self, path: P, s: Cow<str>, mime: &Mime) -> Fallible<()> {
         self.write_bytes(path, s.into_owned().into_bytes(), mime, EncodingType::Plain)
-    }
-
-    fn copy<P: AsRef<Path>, R: io::Read>(&self, r: &mut R, path: P, mime: &Mime) -> Fallible<()> {
-        let mut bytes = Vec::new();
-        io::copy(r, &mut bytes)?;
-        self.write_bytes(path, bytes, mime, EncodingType::Plain)
     }
 }
 

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use crate::server::github::GitHub;
 use crate::server::{Data, GithubData};
+use std::fmt::Write;
 
 pub enum Label {
     ExperimentQueued,
@@ -61,10 +62,10 @@ impl Message {
 
         let mut message = String::new();
         for line in self.lines {
-            message.push_str(&format!(":{}: {}\n", line.emoji, line.content));
+            writeln!(&mut message, ":{}: {}", line.emoji, line.content).unwrap();
         }
         for line in self.notes {
-            message.push_str(&format!("\n:{}: {}", line.emoji, line.content));
+            write!(&mut message, "\n:{}: {}", line.emoji, line.content).unwrap();
         }
 
         github_data.api.post_comment(issue_url, &message)?;

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -190,6 +190,13 @@ impl RecordProgressThread {
                         crate::utils::report_failure(&e);
                     }
 
+                    if let Err(e) = db.clear_stale_records() {
+                        // Not a hard failure. We can continue even if we failed
+                        // to clear records from already completed runs...
+                        log::error!("Failed to clear stale records: {:?}", e);
+                        crate::utils::report_failure(&e);
+                    }
+
                     metrics
                         .crater_endpoint_time
                         .with_label_values(&["record_progress"])


### PR DESCRIPTION
Experiments that are completed (set only after report generation completes) now have the results purged from the database automatically as we collect the next experiment's data. This is not an ideal fix -- probably it would be better to do this by avoiding putting the results into local storage in the first place (uploading directly to S3 instead), but currently that would be fairly annoying to implement, so we prefer this much simpler first step.

This should already make Crater maintenance much more hands off, since the disk will no longer regularly fill up every ~1-2 months.