### PR TITLE
Drop result kinds from experiment page

### DIFF
--- a/templates/ui/experiment.html
+++ b/templates/ui/experiment.html
@@ -106,18 +106,6 @@
                         {% endif %}
                     </table>
                 </div>
-                {% if experiment.result_counts | length > 0 %}
-                <div class="card">
-                    <table class="details">
-                {% for result_count in experiment.result_counts %}
-                    <tr>
-                        <th>{{ result_count.0 }} jobs:</th>
-                        <td>{{ result_count.1}}</td>
-                    </tr>
-                {% endfor %}
-                    </table>
-                </div>
-                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This is a pretty expensive query to compute, and while that could be optimized
with some amount of indexing and creative SQL, it's not clear that this table
delivers much value to the user. If we wanted to present partial reports, that
could be done on a periodic basis (e.g., creating the index.html page every
hour) and would seem largely more useful, but I don't see a clear motivation
for doing so. Triaging crater runs before they're done is unlikely to be useful.

In the meantime, it's better that the UI loads quickly than that we deliver this
data.