### PR TITLE
Check new experiments every two minutes

### DIFF
--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -131,7 +131,7 @@ impl AgentApi {
                 return Ok((experiment, crates));
             }
 
-            ::std::thread::sleep(::std::time::Duration::from_secs(RETRY_AFTER));
+            ::std::thread::sleep(::std::time::Duration::from_secs(120));
         })
     }
 


### PR DESCRIPTION
Discovering a new experiment extremely quickly is not really necessary for
agents, so avoid hitting the server every 5 seconds (from ~4 machines) for this
information.

We might also ideally want some jitter here, but that is somewhat annoying to
add and doesn't seem particularly necessary.