### PR TITLE
Health checks for crater agents

### DIFF
--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -500,7 +500,7 @@ impl Experiment {
         }
     }
 
-    pub fn handle_failure(&mut self, db: &Database, agent: &Assignee) -> Fallible<()> {
+    pub fn clear_agent_progress(&mut self, db: &Database, agent: &str) -> Fallible<()> {
         // Mark all the running crates from this agent as queued (so that they
         // run again)
         db.execute(
@@ -514,7 +514,7 @@ impl Experiment {
                 &Status::Queued.to_string(),
                 &self.name,
                 &Status::Running.to_string(),
-                &agent.to_string(),
+                &Assignee::Agent(agent.to_string()).to_string(),
             ],
         )?;
         Ok(())
@@ -1096,7 +1096,7 @@ mod tests {
             .get_uncompleted_crates(&db, &config, &agent1)
             .unwrap()
             .is_empty());
-        ex.handle_failure(&db, &agent1).unwrap();
+        ex.clear_agent_progress(&db, "agent-1").unwrap();
         assert!(Experiment::next(&db, &agent1).unwrap().is_some());
         assert_eq!(ex.status, Status::Running);
         assert!(!ex

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -78,6 +78,8 @@ pub fn run_ex<DB: WriteResults + Sync>(
         i += 1;
     }
 
+    crate::agent::set_healthy();
+
     info!("uninstalling toolchains...");
     // Clean out all the toolchains currently installed. This minimizes the
     // amount of disk space used by the base system, letting the task execution

--- a/src/runner/worker.rs
+++ b/src/runner/worker.rs
@@ -55,6 +55,10 @@ impl<'a, DB: WriteResults + Sync> Worker<'a, DB> {
 
     fn run_task(&self, task: &Task) -> Result<(), (failure::Error, TestResult)> {
         info!("running task: {:?}", task);
+
+        // If we're running a task, we call ourselves healthy.
+        crate::agent::set_healthy();
+
         let res = task.run(
             self.config,
             self.workspace,

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -323,7 +323,7 @@ fn endpoint_error(
         .ok_or_else(|| err_msg("no experiment run by this agent"))?;
 
     data.metrics.record_error(&auth.name, &ex.name);
-    ex.handle_failure(&data.db, &Assignee::Agent(auth.name))?;
+    ex.clear_agent_progress(&data.db, &auth.name)?;
 
     Ok(ApiResponse::Success { result: true }.into_response()?)
 }


### PR DESCRIPTION
Our heartbeats are a push API and are OK, but we want an API that's usable for managed instance groups on GCP and their equivalents elsewhere to more finely measure crater being up. Currently that's a listening TCP socket (that just accepts and terminates connections immediately).