### PR TITLE
Don't go unhealthy when idle between experiments

### DIFF
--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -131,6 +131,10 @@ impl AgentApi {
                 return Ok((experiment, crates));
             }
 
+            // If we're just waiting for an experiment, we should be considered
+            // healthy.
+            crate::agent::set_healthy();
+
             ::std::thread::sleep(::std::time::Duration::from_secs(120));
         })
     }


### PR DESCRIPTION
We'll likely want to turn off our VMs during such periods but that's
a separate question and not really a health check one.