### PR TITLE
Switch crate queue to retrieve crates based on timeout

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -471,7 +471,7 @@ impl Crater {
                     let res = runner::run_ex(
                         &experiment,
                         &workspace,
-                        &experiment.get_uncompleted_crates(&db, &config, &Assignee::CLI)?,
+                        &experiment.get_uncompleted_crates(&db, &config)?,
                         &result_db,
                         threads,
                         &config,

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -371,6 +371,15 @@ fn migrations() -> Vec<(&'static str, MigrationKind)> {
         })),
     ));
 
+    migrations.push((
+        "create_experiment_time_column",
+        MigrationKind::SQL("alter table experiment_crates add column started_at text;"),
+    ));
+    migrations.push((
+        "create_agent_assignment",
+        MigrationKind::SQL("alter table agents add column latest_work_for text;"),
+    ));
+
     migrations
 }
 

--- a/src/server/agents.rs
+++ b/src/server/agents.rs
@@ -278,8 +278,7 @@ mod tests {
         let (_new, ex) = Experiment::next(&db, &Assignee::Agent("agent".to_string()))
             .unwrap()
             .unwrap();
-        ex.get_uncompleted_crates(&db, &config, &Assignee::Agent("agent".to_string()))
-            .unwrap();
+        ex.get_uncompleted_crates(&db, &config).unwrap();
 
         // After an experiment is assigned to the agent, the agent is working
         let agent = agents.get("agent").unwrap().unwrap();

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -245,7 +245,7 @@ mod tests {
         .apply(&ctx)
         .unwrap();
         let ex = Experiment::next(&db, &assignee).unwrap().unwrap().1;
-        ex.get_uncompleted_crates(&db, &config, &assignee).unwrap();
+        ex.get_uncompleted_crates(&db, &config).unwrap();
         METRICS.update_agent_status(&db, &agent_list_ref).unwrap();
 
         // There are no experiments in the queue but agent1 is still executing the

--- a/src/server/routes/ui/experiments.rs
+++ b/src/server/routes/ui/experiments.rs
@@ -25,7 +25,6 @@ impl ExperimentData {
             Status::Queued => ("", "Queued", true),
             Status::Running => ("orange", "Running", true),
             Status::NeedsReport => ("orange", "Needs report", false),
-            Status::Failed => ("red", "Failed", false),
             Status::GeneratingReport => ("orange", "Generating report", false),
             Status::ReportFailed => ("red", "Report failed", false),
             Status::Completed => ("green", "Completed", false),
@@ -65,7 +64,6 @@ pub fn endpoint_queue(data: Arc<Data>) -> Fallible<Response<Body>> {
     let mut queued = Vec::new();
     let mut running = Vec::new();
     let mut needs_report = Vec::new();
-    let mut failed = Vec::new();
     let mut generating_report = Vec::new();
     let mut report_failed = Vec::new();
 
@@ -81,7 +79,6 @@ pub fn endpoint_queue(data: Arc<Data>) -> Fallible<Response<Body>> {
             Status::Queued => queued.push(ex),
             Status::Running => running.push(ex),
             Status::NeedsReport => needs_report.push(ex),
-            Status::Failed => failed.push(ex),
             Status::GeneratingReport => generating_report.push(ex),
             Status::ReportFailed => report_failed.push(ex),
             Status::Completed => unreachable!(),
@@ -92,7 +89,6 @@ pub fn endpoint_queue(data: Arc<Data>) -> Fallible<Response<Body>> {
     experiments.append(&mut report_failed);
     experiments.append(&mut generating_report);
     experiments.append(&mut needs_report);
-    experiments.append(&mut failed);
     experiments.append(&mut running);
     experiments.append(&mut queued);
 

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -236,10 +236,6 @@ pub fn retry(
     let name = get_name(&data.db, issue, args.name)?;
 
     if let Some(mut experiment) = Experiment::get(&data.db, &name)? {
-        if experiment.status != Status::Failed {
-            bail!("Experiment **`{}`** didn't fail!", name);
-        }
-
         experiment.set_status(&data.db, Status::Queued)?;
         data.reports_worker.wake();
 


### PR DESCRIPTION
Previously, a given crate was assigned to a particular agent, and then that
agent had to either complete or fail (e.g., panic) before it was 'released' for
another agent to attempt. This is error prone, and makes it harder for agents to
be ephemeral (including their name), as it means that it requires manual
intervention if an agent just vanishes to put the assigned crates back into the
general queue.

We switch to a different assignment scheme. Now, when an agent requests crates
from a given experiment, we will dequeue crates that are queued (i.e.,
incomplete) and that have not started yet **or** have started >20 minutes ago.
The current agent timeout is blanket set at 15 minutes, and even if it was
longer, we expect that most crates build quite quickly. Duplicate builds are
also fine for our case (we'll just get a couple extra results but that'll be
deduplicated already when inserting into that table).