### PR TITLE
Rework getting next crate to be per-worker, rather than a global queue

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,11 +12,6 @@ remove = "^S-"
 experiment-queued = "S-waiting-on-crater"
 experiment-completed = "S-waiting-on-review"
 
-[server.distributed]
-# Number of crates in each chunk when running distributed experiments
-# A negative value selects all the available crates
-chunk-size = 1024
-
 # This section contains the list of tested crates when defining an experiment
 # with `--crate-select demo`.
 

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -120,15 +120,15 @@ impl AgentApi {
         })
     }
 
-    pub fn next_experiment(&self) -> Fallible<(Experiment, Vec<Crate>)> {
+    pub fn next_experiment(&self) -> Fallible<Experiment> {
         self.retry(|this| loop {
             let resp: Option<_> = this
-                .build_request(Method::GET, "next-experiment")
+                .build_request(Method::POST, "next-experiment")
                 .send()?
                 .to_api_response()?;
 
-            if let Some((experiment, crates)) = resp {
-                return Ok((experiment, crates));
+            if let Some(experiment) = resp {
+                return Ok(experiment);
             }
 
             // If we're just waiting for an experiment, we should be considered
@@ -136,6 +136,15 @@ impl AgentApi {
             crate::agent::set_healthy();
 
             ::std::thread::sleep(::std::time::Duration::from_secs(120));
+        })
+    }
+
+    pub fn next_crate(&self, ex: &str) -> Fallible<Option<Crate>> {
+        self.retry(|this| loop {
+            this.build_request(Method::POST, "next-crate")
+                .json(&json!(ex))
+                .send()?
+                .to_api_response()?
         })
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -468,13 +468,16 @@ impl Crater {
                     let workspace = self
                         .workspace(docker_env.as_ref().map(|s| s.as_str()), fast_workspace_init)?;
                     workspace.purge_all_build_dirs()?;
+
+                    let crates =
+                        std::sync::Mutex::new(experiment.get_uncompleted_crates(&db, None)?);
                     let res = runner::run_ex(
                         &experiment,
                         &workspace,
-                        &experiment.get_uncompleted_crates(&db, &config)?,
                         &result_db,
                         threads,
                         &config,
+                        &|| Ok(crates.lock().unwrap().pop()),
                     );
                     workspace.purge_all_build_dirs()?;
                     res?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,6 @@ fn default_false() -> bool {
 pub struct ServerConfig {
     pub bot_acl: BotACL,
     pub labels: ServerLabels,
-    pub distributed: ChunkConfig,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -76,12 +75,6 @@ pub struct SandboxConfig {
     pub memory_limit: Size,
     pub build_log_max_size: Size,
     pub build_log_max_lines: usize,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct ChunkConfig {
-    pub chunk_size: i32,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -136,10 +129,6 @@ impl Config {
 
     pub fn demo_crates(&self) -> &DemoCrates {
         &self.demo_crates
-    }
-
-    pub fn chunk_size(&self) -> i32 {
-        self.server.distributed.chunk_size
     }
 
     pub fn check(file: &Option<String>) -> Fallible<()> {
@@ -269,7 +258,6 @@ impl Default for Config {
                     experiment_queued: "".into(),
                     experiment_completed: "".into(),
                 },
-                distributed: ChunkConfig { chunk_size: 1 },
             },
         }
     }
@@ -300,8 +288,6 @@ mod tests {
             "remove = \"\"\n",
             "experiment-queued = \"\"\n",
             "experiment-completed = \"\"\n",
-            "[server.distributed]\n",
-            "chunk-size = 32\n",
             "[demo-crates]\n",
             "crates = []\n",
             "github-repos = []\n",
@@ -338,7 +324,5 @@ mod tests {
             name: "cargo".into(),
             sha: None,
         })));
-
-        assert_eq!(list.chunk_size(), 32);
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -58,7 +58,6 @@ impl Database {
     #[cfg(test)]
     pub fn temp() -> Fallible<Self> {
         let tempfile = NamedTempFile::new()?;
-        dbg!(&tempfile.path());
         Database::new(
             SqliteConnectionManager::file(tempfile.path()),
             Some(tempfile),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -58,6 +58,7 @@ impl Database {
     #[cfg(test)]
     pub fn temp() -> Fallible<Self> {
         let tempfile = NamedTempFile::new()?;
+        dbg!(&tempfile.path());
         Database::new(
             SqliteConnectionManager::file(tempfile.path()),
             Some(tempfile),

--- a/src/server/agents.rs
+++ b/src/server/agents.rs
@@ -28,11 +28,6 @@ pub struct Agent {
 impl Agent {
     fn with_experiment(mut self, db: &Database) -> Fallible<Self> {
         self.experiment = Experiment::run_by(db, &Assignee::Agent(self.name.clone()))?;
-        eprintln!(
-            "{} has experiment {:?}",
-            self.name,
-            self.experiment.as_ref().map(|e| &e.name)
-        );
         Ok(self)
     }
 
@@ -287,8 +282,6 @@ mod tests {
 
         // After an experiment is assigned to the agent, the agent is working
         let agent = agents.get("agent").unwrap().unwrap();
-        dbg!(agent.status());
-        std::thread::sleep(std::time::Duration::from_secs(100000));
         assert_eq!(agent.status(), AgentStatus::Working);
     }
 

--- a/src/server/agents.rs
+++ b/src/server/agents.rs
@@ -28,6 +28,11 @@ pub struct Agent {
 impl Agent {
     fn with_experiment(mut self, db: &Database) -> Fallible<Self> {
         self.experiment = Experiment::run_by(db, &Assignee::Agent(self.name.clone()))?;
+        eprintln!(
+            "{} has experiment {:?}",
+            self.name,
+            self.experiment.as_ref().map(|e| &e.name)
+        );
         Ok(self)
     }
 
@@ -278,10 +283,12 @@ mod tests {
         let (_new, ex) = Experiment::next(&db, &Assignee::Agent("agent".to_string()))
             .unwrap()
             .unwrap();
-        ex.get_uncompleted_crates(&db, &config).unwrap();
+        ex.get_uncompleted_crates(&db, None).unwrap();
 
         // After an experiment is assigned to the agent, the agent is working
         let agent = agents.get("agent").unwrap().unwrap();
+        dbg!(agent.status());
+        std::thread::sleep(std::time::Duration::from_secs(100000));
         assert_eq!(agent.status(), AgentStatus::Working);
     }
 

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -245,7 +245,7 @@ mod tests {
         .apply(&ctx)
         .unwrap();
         let ex = Experiment::next(&db, &assignee).unwrap().unwrap().1;
-        ex.get_uncompleted_crates(&db, &config).unwrap();
+        ex.get_uncompleted_crates(&db, None).unwrap();
         METRICS.update_agent_status(&db, &agent_list_ref).unwrap();
 
         // There are no experiments in the queue but agent1 is still executing the


### PR DESCRIPTION
The previous commit added the notion of timeouts on retrieved crates from the
server, which meant that when an agent (which has multiple workers) requested
the 1024 crates from the server, the tail of that request would likely have
timed out by the time the agent started/completed working on those crates. This
isn't technically a problem, but it is likely to lead to duplicated work for
that tail which is a performance issue, so we avoid it by retrieving crates one at a
time with the new commit.