### PR TITLE
Allow to specify `RUSTDOCFLAGS` independently

### DIFF
--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -99,11 +99,11 @@ fn run_cargo<DB: WriteResults>(
         rustflags.push_str(tc_rustflags);
     }
 
-    let rustflags_env = if let Some(&"doc") = args.first() {
-        "RUSTDOCFLAGS"
-    } else {
-        "RUSTFLAGS"
-    };
+    let mut rustdocflags = format!("--cap-lints={}", ctx.experiment.cap_lints.to_str());
+    if let Some(ref tc_rustdocflags) = ctx.toolchain.rustdocflags {
+        rustdocflags.push(' ');
+        rustdocflags.push_str(tc_rustdocflags);
+    }
 
     let mut did_ice = false;
     let mut did_network = false;
@@ -170,7 +170,8 @@ fn run_cargo<DB: WriteResults>(
         .args(&args)
         .env("CARGO_INCREMENTAL", "0")
         .env("RUST_BACKTRACE", "full")
-        .env(rustflags_env, rustflags);
+        .env("RUSTFLAGS", rustflags)
+        .env("RUSTDOCFLAGS", rustdocflags);
     for (var, data) in env {
         command = command.env(var, data);
     }

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -72,6 +72,7 @@ pub fn run(
             detected_start = Some(Toolchain {
                 source: RustwideToolchain::ci(&build.base_sha, false),
                 rustflags: None,
+                rustdocflags: None,
                 cargoflags: None,
                 ci_try: false,
                 patches: Vec::new(),
@@ -79,6 +80,7 @@ pub fn run(
             detected_end = Some(Toolchain {
                 source: RustwideToolchain::ci(&build.merge_sha, false),
                 rustflags: None,
+                rustdocflags: None,
                 cargoflags: None,
                 ci_try: true,
                 patches: Vec::new(),


### PR DESCRIPTION
Currently, if you to run this experiment:

```
cargo run -- define-ex --ex rustdoc-json-broken --mode rustdoc \
    --cap-lints warn --crate-select list:serde \
    "nightly-2022-06-01+rustflags=-Z unstable-options --output-format json" \
    "nightly+rustflags=-Z unstable-options --output-format json" \
```

crater will mix up `RUSTFLAGS` and `RUSTDOCFLAGS` and you will get the following error:

```
[INFO] [stderr]   process didn't exit successfully: `rustc - --crate-name ___ \
    --print=file-names --cap-lints=warn -Z unstable-options --output-format json \
    --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib \
    --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` \
    (exit status: 1)
[INFO] [stderr]   --- stderr
[INFO] [stderr]   error: Unrecognized option: 'output-format'
```

Solve this by allowing `rustdoc` and `rustdocflags` to be specified independently. After this change, this works without unexpected errors:

```
cargo run -- define-ex --ex rustdoc-json-ice --mode rustdoc \
    --cap-lints warn --crate-select list:serde \
    "nightly-2022-06-01+rustdocflags=-Z unstable-options --output-format json" \
    "nightly+rustdocflags=-Z unstable-options --output-format json"
```

Not sure if this change breaks compatibility in some way, but it seems like a rather generic and future-proof solution to me.