### PR TITLE
Enable retries in the SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "aws-sdk-s3",
+ "aws-smithy-async",
  "aws-smithy-http",
  "aws-types",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ indexmap = "1.4.0"
 tokio = "1.18"
 aws-types = { version = "0.46", features = ["hardcoded-credentials"] }
 aws-smithy-http = "0.46"
+aws-smithy-async = "0.46"
 aws-sdk-s3 = "0.16"
 
 [dev-dependencies]

--- a/src/server/reports.rs
+++ b/src/server/reports.rs
@@ -28,6 +28,11 @@ fn generate_report(data: &Data, ex: &Experiment, results: &DatabaseDB) -> Fallib
         }
     }
     config.set_credentials_provider(Some(data.tokens.reports_bucket.to_aws_credentials()));
+    // https://github.com/awslabs/aws-sdk-rust/issues/586 -- without this, the
+    // SDK will just completely not retry requests.
+    config.set_sleep_impl(Some(Arc::new(
+        aws_smithy_async::rt::sleep::TokioSleep::new(),
+    )));
     let config = config.build();
     let client = aws_sdk_s3::Client::new(&config);
     let writer = report::S3Writer::create(


### PR DESCRIPTION
It sounds like the previous definition for the SdkConfig would fail to configure a sleep impl, and currently that means that we're just silently not retrying any requests. This is obviously not what we want, and likely explains the repeated errors we saw on https://github.com/rust-lang/rust/pull/99389 when generating the report.