### PR TITLE
Add catboost2-sys as flaky

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -51,6 +51,7 @@ alumina = { skip = true } # flaky build
 atlas-coverage-core = { skip-tests = true } # flaky tests
 bitrust = { skip = true } # buggy build script
 caesarlib = { skip-tests = true } # flaky test
+catboost2-sys = { skip = true } # requires rustfmt
 cc = { skip-tests = true } # flaky test
 chef_api = { skip-tests = true } # flaky tests
 ci_info = { skip-tests = true } # flaky tests


### PR DESCRIPTION
[build failed](https://crater-reports.s3.amazonaws.com/pr-99447/try%23ff47dd48ed0d02534055e0033cf766ce528f8ebc/reg/catboost2-sys-0.1.1%2Bcatboost.1.0.5/log.txt) in https://github.com/rust-lang/rust/pull/99447#issuecomment-1211820382; build requires rustfmt.

I'm not sure if this is how best to note this, but I'm doing my part to try to help minimize spurious regressions.