### PR TITLE
Add support for specifying the target to run

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -153,6 +153,8 @@ following flags:
   by the experiment mode, e.g. `+cargoflags=-Zavoid-dev-deps`
 * `+patch={crate_name}={git_repo_url}={branch}`: patches all crates built by
   this toolchain to resolve the given crate from the given git repository and branch.
+* `+target={target_name}`: installs the specified target and passes `--target {target-name}`
+  to Cargo when building, e.g. `+target=i686-unknown-linux-musl`.
 
 ## Commands reference
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -51,7 +51,7 @@ impl Capabilities {
     pub fn for_agent(db: &Database, agent: &str) -> Fallible<Self> {
         let caps = db.query(
             "SELECT capability FROM agent_capabilities WHERE agent_name = ?1",
-            &[&agent],
+            [&agent],
             |r| r.get::<_, String>(0),
         )?;
 
@@ -153,7 +153,7 @@ fn run_experiment(
     db: &ResultsUploader,
     threads_count: usize,
     past_experiment: &mut Option<String>,
-) -> Result<(), (Option<Experiment>, Error)> {
+) -> Result<(), (Option<Box<Experiment>>, Error)> {
     let ex = agent.experiment().map_err(|e| (None, e))?;
 
     if Some(&ex.name) != past_experiment.as_ref() {
@@ -177,7 +177,7 @@ fn run_experiment(
     crate::runner::run_ex(&ex, workspace, db, threads_count, &agent.config, &|| {
         agent.next_crate(&ex.name)
     })
-    .map_err(|err| (Some(ex), err))?;
+    .map_err(|err| (Some(Box::new(ex)), err))?;
     Ok(())
 }
 

--- a/src/crates/lists.rs
+++ b/src/crates/lists.rs
@@ -48,7 +48,7 @@ pub(crate) trait List {
     fn get(db: &Database) -> Fallible<Vec<Crate>> {
         let crates_results = db.query(
             "SELECT crate FROM crates WHERE list = ?1 ORDER BY rowid;",
-            &[&Self::NAME],
+            [&Self::NAME],
             |r| r.get::<_, String>(0),
         )?;
 

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -408,7 +408,7 @@ pub fn execute(db: &mut Connection) -> Fallible<()> {
             }
             .with_context(|_| format!("error running migration: {}", name))?;
 
-            t.execute("INSERT INTO migrations (name) VALUES (?1)", &[&name])?;
+            t.execute("INSERT INTO migrations (name) VALUES (?1)", [&name])?;
             t.commit()?;
 
             info!("executed migration: {}", name);

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -268,7 +268,7 @@ impl Experiment {
     pub fn unfinished(db: &Database) -> Fallible<Vec<Experiment>> {
         let records = db.query(
             "SELECT * FROM experiments WHERE status != ?1 ORDER BY priority DESC, created_at;",
-            &[&Status::Completed.to_str()],
+            [&Status::Completed.to_str()],
             |r| ExperimentDBRecord::from_row(r),
         )?;
         records
@@ -283,7 +283,7 @@ impl Experiment {
                 select latest_work_for from agents where ('agent:' || agents.name) = ?1
             ) and status = ?2 \
             limit 1",
-            &[&assignee.to_string(), Status::Running.to_str()],
+            [&assignee.to_string(), Status::Running.to_str()],
             |r| ExperimentDBRecord::from_row(r),
         )?;
 
@@ -483,7 +483,7 @@ impl Experiment {
     pub fn get(db: &Database, name: &str) -> Fallible<Option<Experiment>> {
         let record = db.get_row(
             "SELECT * FROM experiments WHERE name = ?1;",
-            &[&name],
+            [&name],
             |r| ExperimentDBRecord::from_row(r),
         )?;
 
@@ -552,7 +552,7 @@ impl Experiment {
         let results_len: u32 = db
             .get_row(
                 "SELECT COUNT(*) AS count FROM results WHERE experiment = ?1;",
-                &[&self.name.as_str()],
+                [&self.name.as_str()],
                 |r| r.get("count"),
             )?
             .unwrap();
@@ -561,7 +561,7 @@ impl Experiment {
             .get_row(
                 "SELECT COUNT(*) AS count FROM experiment_crates \
                  WHERE experiment = ?1 AND skipped = 0;",
-                &[&self.name.as_str()],
+                [&self.name.as_str()],
                 |r| r.get("count"),
             )?
             .unwrap();
@@ -573,7 +573,7 @@ impl Experiment {
         let results: Vec<(String, u32)> = db.query(
             "SELECT result, COUNT(*) FROM results \
              WHERE experiment = ?1 GROUP BY result;",
-            &[&self.name.as_str()],
+            [&self.name.as_str()],
             |r| Ok((r.get::<_, String>(0)?, r.get(1)?)),
         )?;
 
@@ -596,7 +596,7 @@ impl Experiment {
     pub fn get_crates(&self, db: &Database) -> Fallible<Vec<Crate>> {
         db.query(
             "SELECT crate FROM experiment_crates WHERE experiment = ?1;",
-            &[&self.name],
+            [&self.name],
             |r| r.get(0),
         )?
         .into_iter()

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -481,11 +481,9 @@ impl Experiment {
     }
 
     pub fn get(db: &Database, name: &str) -> Fallible<Option<Experiment>> {
-        let record = db.get_row(
-            "SELECT * FROM experiments WHERE name = ?1;",
-            [&name],
-            |r| ExperimentDBRecord::from_row(r),
-        )?;
+        let record = db.get_row("SELECT * FROM experiments WHERE name = ?1;", [&name], |r| {
+            ExperimentDBRecord::from_row(r)
+        })?;
 
         if let Some(record) = record {
             Ok(Some(record.into_experiment()?))

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
             "command failed"
         }
     );
-    process::exit(if success { 0 } else { 1 });
+    process::exit(i32::from(!success));
 }
 
 fn main_() -> Fallible<()> {

--- a/src/results/db.rs
+++ b/src/results/db.rs
@@ -150,7 +150,7 @@ impl<'a> ReadResults for DatabaseDB<'a> {
             "SELECT log, encoding FROM results \
              WHERE experiment = ?1 AND toolchain = ?2 AND crate = ?3 \
              LIMIT 1;",
-            &[&ex.name, &toolchain.to_string(), &krate.id()],
+            [&ex.name, &toolchain.to_string(), &krate.id()],
             |row| {
                 let log: Vec<u8> = row.get("log")?;
                 let encoding: String = row.get("encoding")?;
@@ -176,7 +176,7 @@ impl<'a> ReadResults for DatabaseDB<'a> {
                 "SELECT result FROM results \
                  WHERE experiment = ?1 AND toolchain = ?2 AND crate = ?3 \
                  LIMIT 1;",
-                &[&ex.name, &toolchain.to_string(), &krate.id()],
+                [&ex.name, &toolchain.to_string(), &krate.id()],
                 |row| row.get("result"),
             )?
             .pop();

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -99,6 +99,9 @@ pub fn run_ex<DB: WriteResults + Sync>(
         if ex.mode == Mode::Clippy {
             tc.add_component(workspace, "clippy")?;
         }
+        if let Some(requested_target) = &tc.target {
+            tc.add_target(workspace, requested_target)?;
+        }
     }
 
     info!("running tasks in {} threads...", threads_count);

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -89,6 +89,9 @@ fn run_cargo<DB: WriteResults>(
     let local_packages_id: HashSet<_> = local_packages.iter().map(|p| &p.id).collect();
 
     let mut args = args.to_vec();
+    if let Some(ref target) = ctx.toolchain.target {
+        args.extend(["--target", target]);
+    }
     if let Some(ref tc_cargoflags) = ctx.toolchain.cargoflags {
         args.extend(tc_cargoflags.split(' '));
     }

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -71,6 +71,7 @@ pub fn run(
         {
             detected_start = Some(Toolchain {
                 source: RustwideToolchain::ci(&build.base_sha, false),
+                target: None,
                 rustflags: None,
                 rustdocflags: None,
                 cargoflags: None,
@@ -79,6 +80,7 @@ pub fn run(
             });
             detected_end = Some(Toolchain {
                 source: RustwideToolchain::ci(&build.merge_sha, false),
+                target: None,
                 rustflags: None,
                 rustdocflags: None,
                 cargoflags: None,

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -311,7 +311,7 @@ fn store_experiment_name(db: &Database, issue: &Issue, name: &str) -> Fallible<(
 fn default_experiment_name(db: &Database, issue: &Issue) -> Fallible<Option<String>> {
     let name = db.get_row(
         "SELECT experiment FROM saved_names WHERE issue = ?1",
-        &[&issue.number],
+        [&issue.number],
         |r| r.get(0),
     )?;
 

--- a/src/server/try_builds.rs
+++ b/src/server/try_builds.rs
@@ -51,7 +51,7 @@ pub(crate) fn detect(
 pub(crate) fn get_sha(db: &Database, repo: &str, pr: i32) -> Fallible<Option<TryBuild>> {
     db.get_row(
         "SELECT base_sha, merge_sha FROM try_builds WHERE repo = ?1 AND pr = ?2;",
-        &[repo, &pr.to_string()],
+        [repo, &pr.to_string()],
         |row| {
             Ok(TryBuild {
                 base_sha: row.get("base_sha")?,


### PR DESCRIPTION
This allows you to choose a target other than `x86_64-unknown-linux-gnu` on the current runners such as `i686-unknown-linux-musl`:

```
$ cargo run -- define-ex --crate-select=demo --cap-lints=forbid stable+target=i686-unknown-linux-musl beta+target=i686-unknown-linux-musl
[2022-10-06T21:09:31Z INFO  crater] command succeeded

$ cargo run -- run-graph --threads 1
...
[2022-10-06T21:00:05Z INFO  rustwide::toolchain] adding target i686-unknown-linux-musl for toolchain stable
[2022-10-06T21:00:05Z INFO  rustwide::cmd] running `Command { std: "/home/azureuser/disk1/crater/work/cargo-home/bin/rustup" "target" "add" "--toolchain" "stable" "i686-unknown-linux-musl", kill_on_drop: false }`
[2022-10-06T21:00:05Z INFO  rustwide::cmd] [stderr] info: downloading component 'rust-std' for 'i686-unknown-linux-musl'
[2022-10-06T21:00:05Z INFO  rustwide::cmd] [stderr] info: installing component 'rust-std' for 'i686-unknown-linux-musl'
...
[2022-10-06T21:00:18Z INFO  rustwide::cmd] [stderr] info: checking for self-updates
[2022-10-06T21:00:18Z INFO  rustwide::toolchain] adding target i686-unknown-linux-musl for toolchain beta
[2022-10-06T21:00:18Z INFO  rustwide::cmd] running `Command { std: "/home/azureuser/disk1/crater/work/cargo-home/bin/rustup" "target" "add" "--toolchain" "beta" "i686-unknown-linux-musl", kill_on_drop: false }`
[2022-10-06T21:00:18Z INFO  rustwide::cmd] [stderr] info: downloading component 'rust-std' for 'i686-unknown-linux-musl'
[2022-10-06T21:00:19Z INFO  rustwide::cmd] [stderr] info: installing component 'rust-std' for 'i686-unknown-linux-musl'
[2022-10-06T21:00:21Z INFO  crater::runner] running tasks in 1 threads...
...
[2022-10-06T21:13:05Z INFO  rustwide::cmd] running `Command { std: "docker" "create" "-v" "/home/azureuser/disk1/crater/work/builds/worker-0/target:/opt/rustwide/target:rw,Z" "-v" "/home/azureuser/disk1/crater/work/builds/worker-0/source:/opt/rustwide/workdir:ro,Z" "-v" "/home/azureuser/disk1/crater/work/cargo-home:/opt/rustwide/cargo-home:ro,Z" "-v" "/home/azureuser/disk1/crater/work/rustup-home:/opt/rustwide/rustup-home:ro,Z" "-e" "SOURCE_DIR=/opt/rustwide/workdir" "-e" "CARGO_TARGET_DIR=/opt/rustwide/target" "-e" "CARGO_INCREMENTAL=0" "-e" "RUST_BACKTRACE=full" "-e" "RUSTFLAGS=--cap-lints=forbid" "-e" "RUSTDOCFLAGS=--cap-lints=forbid" "-e" "CARGO_HOME=/opt/rustwide/cargo-home" "-e" "RUSTUP_HOME=/opt/rustwide/rustup-home" "-w" "/opt/rustwide/workdir" "-m" "1610612736" "--user" "1000:998" "--network" "none" "ghcr.io/rust-lang/crates-build-env/linux@sha256:3d1cd00eb6e6ea2a7969240779edeaeff35b24be85036c63b883ba933028a15f" "/opt/rustwide/cargo-home/bin/cargo" "+beta" "test" "--frozen" "--target" "i686-unknown-linux-musl", kill_on_drop: false }`
...
[2022-10-06T21:13:05Z INFO  rustwide::cmd] [stderr]     Finished test [unoptimized + debuginfo] target(s) in 0.00s
[2022-10-06T21:13:05Z INFO  rustwide::cmd] [stderr]      Running unittests src/lib.rs (/opt/rustwide/target/i686-unknown-linux-musl/debug/deps/lazy_static-d189001dd9281e0a)
[2022-10-06T21:13:05Z INFO  rustwide::cmd] [stderr]      Running tests/no_std.rs (/opt/rustwide/target/i686-unknown-linux-musl/debug/deps/no_std-a3be84aa37faf9f2)
[2022-10-06T21:13:05Z INFO  rustwide::cmd] [stderr]      Running tests/test.rs (/opt/rustwide/target/i686-unknown-linux-musl/debug/deps/test-076bce8c3f654325)
...
```

