### PR TITLE
Update rustwide to 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,9 +1171,9 @@ checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
 dependencies = [
  "bitflags",
  "libc",
@@ -1592,15 +1592,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.13.4+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
 dependencies = [
  "cc",
  "libc",
@@ -1900,19 +1900,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
@@ -1920,6 +1907,20 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+dependencies = [
+ "autocfg 1.1.0",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
 ]
 
 [[package]]
@@ -2756,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "rustwide"
-version = "0.14.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad1c7516d4138e9f7bf4b0f56d41585f5aa1ba57dce6df34b4e90ba9db7d18b"
+checksum = "b1b0070cdf593a5b66ba6160974bbfb504a837f8c06f3357a623c9a7b6619c64"
 dependencies = [
  "attohttpc",
  "base64 0.13.0",
@@ -2771,7 +2772,7 @@ dependencies = [
  "http 0.2.8",
  "lazy_static",
  "log 0.4.17",
- "nix 0.20.2",
+ "nix 0.25.0",
  "percent-encoding 2.1.0",
  "remove_dir_all 0.7.0",
  "scopeguard",
@@ -2784,7 +2785,7 @@ dependencies = [
  "tokio-stream",
  "toml 0.5.9",
  "walkdir",
- "winapi 0.3.9",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ hmac = "0.12"
 sha-1 = "0.10"
 rust_team_data = { git = "https://github.com/rust-lang/team" }
 systemstat = "0.1.11"
-rustwide = { version = "0.14.0", features = ["unstable", "unstable-toolchain-ci"] }
+rustwide = { version = "0.15.0", features = ["unstable", "unstable-toolchain-ci"] }
 percent-encoding = "2.1.0"
 remove_dir_all = "0.7"
 ctrlc = "3.1.3"


### PR DESCRIPTION
`rustwide@0.15.2` contains support for installing targets other than the system default using `rustup-toolchain-install-master`. With this support, `try` builds of rustc can now be crater'd on targets other than `x86_64-unknown-linux-gnu`:

```
[2022-10-12T16:42:54Z INFO  rustwide::toolchain] installing toolchain e392e7b50913d5cb6e2c08d70cdeb72e56d289f9
[2022-10-12T16:42:54Z INFO  rustwide::cmd] running `Command { std: "/home/azureuser/disk1/crater/work/cargo-home/bin/rustup-toolchain-install-master" "e392e7b50913d5cb6e2c08d70cdeb72e56d289f9" "-c" "cargo", kill_on_drop: false }`
[2022-10-12T16:42:54Z INFO  rustwide::cmd] [stderr] toolchain `e392e7b50913d5cb6e2c08d70cdeb72e56d289f9` is already installed
[2022-10-12T16:42:54Z INFO  rustwide::toolchain] adding target i686-unknown-linux-musl for toolchain e392e7b50913d5cb6e2c08d70cdeb72e56d289f9
[2022-10-12T16:42:54Z INFO  rustwide::cmd] running `Command { std: "/home/azureuser/disk1/crater/work/cargo-home/bin/rustup-toolchain-install-master" "-f" "--targets" "i686-unknown-linux-musl" "--" "e392e7b50913d5cb6e2c08d70cdeb72e56d289f9", kill_on_drop: false }`
[2022-10-12T16:42:54Z INFO  rustwide::cmd] [stderr] detecting the channel of the `e392e7b50913d5cb6e2c08d70cdeb72e56d289f9` toolchain...
[2022-10-12T16:42:54Z INFO  rustwide::cmd] [stderr] downloading <https://ci-artifacts.rust-lang.org/rustc-builds/e392e7b50913d5cb6e2c08d70cdeb72e56d289f9/rustc-nightly-x86_64-unknown-linux-gnu.tar.xz>...
66.23 MB / 66.23 MB [=====================================] 100.00 % 13.74 MB/s 
[2022-10-12T16:42:59Z INFO  rustwide::cmd] [stderr] downloading <https://ci-artifacts.rust-lang.org/rustc-builds/e392e7b50913d5cb6e2c08d70cdeb72e56d289f9/rust-std-nightly-i686-unknown-linux-musl.tar.xz>...
24.86 MB / 24.86 MB [=====================================] 100.00 % 10.85 MB/s 
[2022-10-12T16:43:02Z INFO  rustwide::cmd] [stderr] downloading <https://ci-artifacts.rust-lang.org/rustc-builds/e392e7b50913d5cb6e2c08d70cdeb72e56d289f9/rust-std-nightly-x86_64-unknown-linux-gnu.tar.xz>...
30.11 MB / 30.11 MB [=====================================] 100.00 % 12.33 MB/s 
[2022-10-12T16:43:04Z INFO  rustwide::cmd] [stderr] toolchain `e392e7b50913d5cb6e2c08d70cdeb72e56d289f9` is successfully installed!
[2022-10-12T16:43:04Z INFO  rustwide::toolchain] installing toolchain 8dae881ac166f8debe04e17604ebbe2ab47083fd
...
[2022-10-12T16:43:15Z INFO  rustwide::cmd] running `Command { std: "docker" "create" "-v" "/home/azureuser/disk1/crater/work/builds/worker-0/target:/opt/rustwide/target:rw,Z" "-v" "/home/azureuser/disk1/crater/work/builds/worker-0/source:/opt/rustwide/workdir:ro,Z" "-v" "/home/azureuser/disk1/crater/work/cargo-home:/opt/rustwide/cargo-home:ro,Z" "-v" "/home/azureuser/disk1/crater/work/rustup-home:/opt/rustwide/rustup-home:ro,Z" "-e" "SOURCE_DIR=/opt/rustwide/workdir" "-e" "CARGO_TARGET_DIR=/opt/rustwide/target" "-e" "CARGO_INCREMENTAL=0" "-e" "RUST_BACKTRACE=full" "-e" "RUSTFLAGS=--cap-lints=forbid" "-e" "RUSTDOCFLAGS=--cap-lints=forbid" "-e" "CARGO_HOME=/opt/rustwide/cargo-home" "-e" "RUSTUP_HOME=/opt/rustwide/rustup-home" "-w" "/opt/rustwide/workdir" "-m" "1610612736" "--user" "1000:1000" "--network" "none" "ghcr.io/rust-lang/crates-build-env/linux@sha256:3d1cd00eb6e6ea2a7969240779edeaeff35b24be85036c63b883ba933028a15f" "/opt/rustwide/cargo-home/bin/cargo" "+e392e7b50913d5cb6e2c08d70cdeb72e56d289f9" "test" "--frozen" "--no-run" "--message-format=json" "--target" "i686-unknown-linux-musl", kill_on_drop: false }`
[2022-10-12T16:43:15Z INFO  rustwide::cmd] [stdout] 45dd4059711ff8dba19c347ca7bad238c9f6435480bd6adbcc5f8c8355866580
[2022-10-12T16:43:15Z INFO  rustwide::cmd] running `Command { std: "docker" "start" "-a" "45dd4059711ff8dba19c347ca7bad238c9f6435480bd6adbcc5f8c8355866580", kill_on_drop: false }`
[2022-10-12T16:43:16Z INFO  rustwide::cmd] [stderr]    Compiling hello-rs v0.1.0 (/opt/rustwide/workdir)
[2022-10-12T16:43:16Z INFO  rustwide::cmd] [stderr]     Finished test [unoptimized + debuginfo] target(s) in 0.18s
...
```