### PR TITLE
Distinct build directories per toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,6 @@ dependencies = [
  "clap",
  "crates-index",
  "crossbeam-channel",
- "crossbeam-utils",
  "csv",
  "ctrlc",
  "difference",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ base64 = "0.20.0"
 bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 crates-index = "0.18"
-crossbeam-utils = "0.8"
 crossbeam-channel = "0.5"
 csv = "1.0.2"
 docsrs-metadata = { git = "https://github.com/rust-lang/docs.rs/" }


### PR DESCRIPTION
We see a number of failures from build scripts or tests failing when run
in the same directory. These are 99% likely to be bugs in that crate,
but Crater's goal isn't to find bugs in crates but bugs/regressions in
rustc, so we should try to avoid sharing a build directory as we did
before.

In practice this additional level of nesting should be minimally
impactful in terms of cache hits, as caching across toolchains wasn't
possible anyway. It may even improve things.

Our purging algorithm is the same as before.