### PR TITLE
Avoid panicking on negative durations

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -545,7 +545,7 @@ impl Crater {
     fn workspace(&self, docker_env: Option<&str>, fast_init: bool) -> Result<Workspace, Error> {
         let mut builder = WorkspaceBuilder::new(&crater::dirs::WORK_DIR, &crater::USER_AGENT)
             .fast_init(fast_init)
-            .fetch_registry_index_during_builds(false)
+            .fetch_registry_index_during_builds(true)
             .command_timeout(Some(Duration::from_secs(15 * 60)))
             .command_no_output_timeout(Some(Duration::from_secs(5 * 60)))
             .running_inside_docker(std::env::var("CRATER_INSIDE_DOCKER").is_ok());

--- a/src/server/routes/ui/experiments.rs
+++ b/src/server/routes/ui/experiments.rs
@@ -127,7 +127,13 @@ struct ExperimentContext {
 }
 
 fn humanize(duration: Duration) -> String {
-    let duration = duration.to_std().expect("non-negative duration");
+    let duration = match duration.to_std() {
+        Ok(d) => d,
+        Err(_) => {
+            // Don't try to make it pretty as a fallback.
+            return format!("{:?}", duration);
+        }
+    };
     if duration.as_secs() < 60 {
         format!("{duration:?}")
     } else if duration.as_secs() < 60 * 60 {


### PR DESCRIPTION
This currently causes a panic when loading a run's details page after it has finished the initial processing (but not yet completed log uploads, I think?).