### PR TITLE
cancel = abort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -521,7 +521,7 @@ impl Crater {
                 } else {
                     default_capabilities_for_target()
                 };
-                caps.extend(capabilities.clone().into_iter());
+                caps.extend(capabilities.clone());
 
                 agent::run(
                     url,

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -169,7 +169,7 @@ mod tests {
             arg2: Option<String> = "arg2",
         })
 
-        "bar" => Bar(BarArgs {
+        "bar" | "bar-alias" => Bar(BarArgs {
             arg3: Option<String> = "arg3",
         })
 
@@ -201,6 +201,7 @@ mod tests {
             })
         );
         test!("bar", TestCommand::Bar(BarArgs { arg3: None }));
+        test!("bar-alias", TestCommand::Bar(BarArgs { arg3: None }));
         test!("", TestCommand::Baz(BazArgs { arg4: None }));
 
         // Test if args are parsed correctly
@@ -226,6 +227,12 @@ mod tests {
         );
         test!(
             "bar arg3=\"foo \\\" bar\"",
+            TestCommand::Bar(BarArgs {
+                arg3: Some("foo \" bar".into()),
+            })
+        );
+        test!(
+            "bar-alias arg3=\"foo \\\" bar\"",
             TestCommand::Bar(BarArgs {
                 arg3: Some("foo \" bar".into()),
             })

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -17,10 +17,10 @@ pub enum CommandParseError {
 
 macro_rules! generate_parser {
     (pub enum $enum:ident {
-        $($command:expr => $variant:ident($var_struct:ident {
+        $($command:pat => $variant:ident($var_struct:ident {
             $($flag:ident: $type:ty = $name:expr,)*
         }))*
-        _ => $d_variant:ident($d_var_struct:ident {$($d_flag:ident: $d_type:ty = $d_name:expr,)*})
+        => $d_variant:ident($d_var_struct:ident {$($d_flag:ident: $d_type:ty = $d_name:expr,)*})
     }) => {
         use crate::prelude::*;
         use std::str::FromStr;
@@ -144,7 +144,7 @@ generate_parser!(pub enum Command {
 
     "reload-acl" => ReloadACL(ReloadACLArgs {})
 
-    _ => Edit(EditArgs {
+    => Edit(EditArgs {
         name: Option<String> = "name",
         start: Option<Toolchain> = "start",
         end: Option<Toolchain> = "end",
@@ -173,7 +173,7 @@ mod tests {
             arg3: Option<String> = "arg3",
         })
 
-        _ => Baz(BazArgs {
+        => Baz(BazArgs {
             arg4: Option<i32> = "arg4",
         })
     });

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -128,7 +128,7 @@ generate_parser!(pub enum Command {
         requirement: Option<String> = "requirement",
     })
 
-    "abort" => Abort(AbortArgs {
+    "abort" | "cancel" => Abort(AbortArgs {
         name: Option<String> = "name",
     })
 


### PR DESCRIPTION
This PR allows patterns to be used in the webhooks command parser, for the sole purpose of accepting `cancel` as an alias to `abort`.

<sub>(this is for @compiler-errors)</sub>