### PR TITLE
Remove RunnerState

### DIFF
--- a/src/agent/results.rs
+++ b/src/agent/results.rs
@@ -1,5 +1,4 @@
 use crate::agent::api::AgentApi;
-use crate::config::Config;
 use crate::crates::Crate;
 use crate::experiments::Experiment;
 use crate::prelude::*;
@@ -48,16 +47,14 @@ impl<'a> WriteResults for ResultsUploader<'a> {
         ex: &Experiment,
         toolchain: &Toolchain,
         krate: &Crate,
-        existing_logs: Option<LogStorage>,
-        config: &Config,
+        storage: &LogStorage,
         _: EncodingType,
         f: F,
     ) -> Fallible<TestResult>
     where
         F: FnOnce() -> Fallible<TestResult>,
     {
-        let storage = existing_logs.unwrap_or_else(|| LogStorage::from(config));
-        let result = logging::capture(&storage, f)?;
+        let result = logging::capture(storage, f)?;
         let output = storage.to_string();
 
         let mut updated = None;

--- a/src/report/archives.rs
+++ b/src/report/archives.rs
@@ -190,6 +190,7 @@ mod tests {
     use crate::results::{DatabaseDB, EncodingType, FailureReason, TestResult, WriteResults};
     use flate2::read::GzDecoder;
     use mime::Mime;
+    use rustwide::logging::LogStorage;
     use std::io::Read;
     use tar::Archive;
 
@@ -217,8 +218,7 @@ mod tests {
                 &ex,
                 &ex.toolchains[0],
                 crate1,
-                None,
-                &config,
+                &LogStorage::from(&config),
                 EncodingType::Gzip,
                 || {
                     info!("tc1 crate1");
@@ -231,8 +231,7 @@ mod tests {
                 &ex,
                 &ex.toolchains[1],
                 crate1,
-                None,
-                &config,
+                &LogStorage::from(&config),
                 EncodingType::Plain,
                 || {
                     info!("tc2 crate1");
@@ -245,8 +244,7 @@ mod tests {
                 &ex,
                 &ex.toolchains[0],
                 crate2,
-                None,
-                &config,
+                &LogStorage::from(&config),
                 EncodingType::Gzip,
                 || {
                     info!("tc1 crate2");
@@ -259,8 +257,7 @@ mod tests {
                 &ex,
                 &ex.toolchains[1],
                 crate2,
-                None,
-                &config,
+                &LogStorage::from(&config),
                 EncodingType::Plain,
                 || {
                     info!("tc2 crate2");

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -1,7 +1,6 @@
 mod db;
 #[cfg(test)]
 mod dummy;
-use crate::config::Config;
 use crate::crates::Crate;
 use crate::experiments::Experiment;
 use crate::prelude::*;
@@ -45,8 +44,7 @@ pub trait WriteResults {
         ex: &Experiment,
         toolchain: &Toolchain,
         krate: &Crate,
-        existing_logs: Option<LogStorage>,
-        config: &Config,
+        existing_logs: &LogStorage,
         encoding_type: EncodingType,
         f: F,
     ) -> Fallible<TestResult>


### PR DESCRIPTION
Store logs into a local stack variable that gets uploaded at the end. There's no reason to keep them in a semi-global place, and this makes it easier to capture more into the logs (e.g., should make us include retry logs automatically).