### PR TITLE
detect new spuroius error and fix a regression considered spurious

### DIFF
--- a/src/report/display.rs
+++ b/src/report/display.rs
@@ -15,6 +15,7 @@ impl ResultName for FailureReason {
             FailureReason::NetworkAccess => "network access".into(),
             FailureReason::OOM => "OOM".into(),
             FailureReason::ICE => "ICE".into(),
+            FailureReason::NoSpace => "no space left on device".into(),
             FailureReason::CompilerError(_) => "compiler error".into(),
             FailureReason::DependsOn(_) => "faulty deps".into(),
             FailureReason::CompilerDiagnosticChange => "compiler diagnostic changed".into(),
@@ -28,6 +29,7 @@ impl ResultName for FailureReason {
             | FailureReason::NetworkAccess
             | FailureReason::Timeout
             | FailureReason::OOM
+            | FailureReason::NoSpace
             | FailureReason::CompilerDiagnosticChange
             | FailureReason::ICE => self.short_name(),
         }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -510,7 +510,7 @@ fn compare(
             | (BuildFail(_), TestSkipped)
             | (BuildFail(_), TestPass)
             | (TestFail(_), TestPass) => Comparison::Fixed,
-
+            (TestFail(_), BuildFail(reason)) if !reason.is_spurious() => Comparison::Regressed,
             (TestFail(reason1), BuildFail(reason2))
                 if reason1.is_spurious() || reason2.is_spurious() =>
             {
@@ -831,6 +831,7 @@ mod tests {
                 TestPass, BuildFail(Unknown) => Regressed;
                 TestSkipped, BuildFail(Unknown) => Regressed;
                 TestFail(Unknown), BuildFail(Unknown) => Regressed;
+                TestFail(OOM), BuildFail(Unknown) => Regressed;
 
                 // ICE is special
                 BuildFail(Unknown), BuildFail(ICE) => Regressed;
@@ -846,7 +847,6 @@ mod tests {
                 TestPass, TestFail(OOM) => SpuriousRegressed;
                 TestPass, BuildFail(OOM) => SpuriousRegressed;
                 TestSkipped, BuildFail(OOM) => SpuriousRegressed;
-                TestFail(OOM), BuildFail(Unknown) => SpuriousRegressed;
                 TestFail(Unknown), BuildFail(OOM) => SpuriousRegressed;
 
                 // Errors

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -194,6 +194,7 @@ impl ::std::str::FromStr for DiagnosticCode {
 pub enum FailureReason {
     Unknown,
     OOM,
+    NoSpace,
     Timeout,
     ICE,
     NetworkAccess,
@@ -209,6 +210,7 @@ impl ::std::fmt::Display for FailureReason {
         match self {
             FailureReason::Unknown => write!(f, "unknown"),
             FailureReason::OOM => write!(f, "oom"),
+            FailureReason::NoSpace => write!(f, "no-space"),
             FailureReason::Timeout => write!(f, "timeout"),
             FailureReason::ICE => write!(f, "ice"),
             FailureReason::NetworkAccess => write!(f, "network-access"),
@@ -265,6 +267,7 @@ impl ::std::str::FromStr for FailureReason {
                 "oom" => Ok(FailureReason::OOM),
                 "timeout" => Ok(FailureReason::Timeout),
                 "ice" => Ok(FailureReason::ICE),
+                "no-space" => Ok(FailureReason::NoSpace),
                 _ => bail!("unexpected value: {}", s),
             }
         }
@@ -275,6 +278,7 @@ impl FailureReason {
     pub(crate) fn is_spurious(&self) -> bool {
         match *self {
             FailureReason::OOM
+            | FailureReason::NoSpace
             | FailureReason::Timeout
             | FailureReason::NetworkAccess
             | FailureReason::CompilerDiagnosticChange => true,
@@ -351,6 +355,7 @@ mod tests {
             "build-fail:compiler-error(001)" => BuildFail(CompilerError(btreeset!["001".parse().unwrap()])),
             "build-fail:oom" => BuildFail(OOM),
             "build-fail:ice" => BuildFail(ICE),
+            "build-fail:no-space" => BuildFail(NoSpace),
             "test-fail:timeout" => TestFail(Timeout),
             "test-pass" => TestPass,
             "error" => Error,


### PR DESCRIPTION
- change from TestFail to non-spuriouse BuildFail is a regression (rust-lang/crater#703)
- no space left on drive is spuriouse (rust-lang/crater#700)