### PR TITLE
Adjust handling of "no space left on device" error

### DIFF
--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -278,11 +278,11 @@ impl FailureReason {
     pub(crate) fn is_spurious(&self) -> bool {
         match *self {
             FailureReason::OOM
-            | FailureReason::NoSpace
             | FailureReason::Timeout
             | FailureReason::NetworkAccess
             | FailureReason::CompilerDiagnosticChange => true,
             FailureReason::CompilerError(_)
+            | FailureReason::NoSpace
             | FailureReason::DependsOn(_)
             | FailureReason::Unknown
             | FailureReason::ICE => false,

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -282,6 +282,10 @@ impl FailureReason {
             | FailureReason::NetworkAccess
             | FailureReason::CompilerDiagnosticChange => true,
             FailureReason::CompilerError(_)
+            // while no space is technically spurious,
+            //  we consider it non-spurious here so it is
+            // - more visible
+            // - included in the `retry-regressed-list.txt`
             | FailureReason::NoSpace
             | FailureReason::DependsOn(_)
             | FailureReason::Unknown

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -202,7 +202,11 @@ fn run_cargo<DB: WriteResults>(
             if did_ice {
                 Err(e.context(FailureReason::ICE).into())
             } else if !deps.is_empty() {
-                Err(e.context(FailureReason::DependsOn(deps)).into())
+                if ran_out_of_space {
+                    Err(e.context(FailureReason::NoSpace).into())
+                } else {
+                    Err(e.context(FailureReason::DependsOn(deps)).into())
+                }
             } else if !error_codes.is_empty() {
                 Err(e.context(FailureReason::CompilerError(error_codes)).into())
             } else if did_network {


### PR DESCRIPTION
1. prefere `NoSpace` reason over `DependsOn`
  - the later is nosiy and hides a simple problem in a long log
2. Change `NoSpace` from spuriouse to non-spuriouse 
  - to keep/move these crates into the `retry-regressed-list.txt` as the DependsOn failiures, that were really `NoSpace` failures, appear to be frequently retried
  
Notes rearding 1. this somewhat mudles the hirarchy of failure reasons,
but I didn't think `NoSpace` should be necessarily be above `CompilerError(_)` and `CompilerDiagnosticChange`

Regarding 2. while technically spuriouse I think it is reasonable to treat `NoSpace` as a non-spuriouse regression for practical reasonse. 
- visibility as spuriouse failiures are a lot less visible 
- `retry-regressed-list.txt`, without adding a secondary `retry-spurious-regressed-list.txt` or splitting spuriouse failiures into retry-able and non-retry-able spuriouse failiures

This somewhat undose my fix for #700 from #713, but at least it should now be its own group/category.