### PR TITLE
Avoid extra allocations while generating HTML reports

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -161,5 +161,7 @@ pub fn render_template<C: Serialize>(name: &str, context: &C) -> Fallible<String
         tera = &TERA_CACHE;
     }
 
-    Ok(tera.render(name, context).to_failure()?)
+    Ok(tera
+        .render(name, context)
+        .map_err(|e| failure::format_err!("{:?}", e))?)
 }

--- a/src/report/display.rs
+++ b/src/report/display.rs
@@ -78,7 +78,7 @@ impl ResultName for TestResult {
     }
 }
 
-#[derive(Serialize)]
+#[derive(PartialEq, Eq, Hash, Serialize)]
 pub enum Color {
     Single(&'static str),
     Striped(&'static str, &'static str),

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -36,10 +36,10 @@
         {% for run in crate.runs %}
             <span class="run">
                 {% if run %}
-                    <b class="r{{ run.res }}"></b>
-                    <a href="{{ run.log|safe }}/log.txt">{{ result_names[run.res] }}</a>
+                    <b class="c{{ run.color_idx }}"></b>
+                    <a href="{{ run.log|safe }}/log.txt">{{ result_names[run.name_idx] }}</a>
                 {% else %}
-                    <b class="c{{ crate.res }}"></b>
+                    <b class="c{{ crate.color_idx }}"></b>
                     {{ crate.res }}
                 {% endif %}
             </span>

--- a/templates/report/results.html
+++ b/templates/report/results.html
@@ -5,18 +5,8 @@
 
 {% block extra_head %}
     <style>
-        {% for color in result_colors %}
-            .r{{ loop.index0 }} {
-                {% if color.Single %}
-                    background: {{ color.Single }};
-                {% elif color.Striped %}
-                    background: repeating-linear-gradient(-45deg, {{ color.Striped[0] }}, {{ color.Striped[0] }} 15px, {{ color.Striped[1] }} 15px, {{ color.Striped[1] }} 30px);
-                {% endif %}
-            }
-        {% endfor %}
-
-        {% for name, color in comparison_colors %}
-            .c{{ name }} {
+        {% for color in colors %}
+            .c{{ loop.index0 }} {
                 {% if color.Single %}
                     background: {{ color.Single }};
                 {% elif color.Striped %}
@@ -31,10 +21,11 @@
     {% if categories %}
         {% for iter in categories %}
             {% set name = iter.0 %}
-            {% set crates = iter.1 %}
+            {% set category_color_idx = iter.1 %}
+            {% set crates = iter.2 %}
             <div class="category">
                 {% if crates.Plain %}
-                    <div class="header c{{ name }} toggle" data-toggle="#crt-{{ name }}">
+                    <div class="header c{{ category_color_idx }} toggle" data-toggle="#crt-{{ name }}">
                         {{ name }} ({{ crates.Plain|length }})
                     </div>
                     <div class="crates hidden" id="crt-{{ name }}">
@@ -44,14 +35,14 @@
                         {% endfor %}
                     </div>
                 {% elif crates.Tree and crates.Tree.count > 0 %}
-                    <div class="header c{{ name }} toggle" data-toggle="#crt-{{ name }}-tr">
+                    <div class="header c{{ category_color_idx }} toggle" data-toggle="#crt-{{ name }}-tr">
                         {{ name }}: dependencies ({{ crates.Tree.count }} root crates, {{info[name]}} {{ name }} crates in total) 
                     </div>
                     <div class="crates hidden" id="crt-{{ name }}-tr">
                     {% for root, subcrates in crates.Tree.tree %}
                             <div class="category">
                                 <div class="flex toggle" data-toggle="#{{ name }}-tr{{ loop.index }}">
-                                    <div class="header c{{ name}} subheader">{{ name}}</div>
+                                    <div class="header c{{ category_color_idx }} subheader">{{ name}}</div>
                                     <div class="header header-background">
                                         {{ root }} ({{ subcrates|length }})
                                     </div>
@@ -66,14 +57,14 @@
                     {% endfor %}
                     </div>
                 {% elif crates.RootResults %}
-                    <div class="header c{{ name }} toggle" data-toggle="#crt-{{ name }}-rt">
+                    <div class="header c{{ category_color_idx }} toggle" data-toggle="#crt-{{ name }}-rt">
                         {{ name }}: root results ({{ crates.RootResults.count }} different results, {{info[name]}} {{ name }} crates in total)
                     </div>
                     <div class="crates hidden" id="crt-{{ name }}-rt">
                     {% for result, subcrates in crates.RootResults.results %}
                             <div class="category">
                                 <div class="flex toggle" data-toggle="#{{ name }}-rt{{ loop.index }}">
-                                    <div class="header c{{ name}} subheader">{{ name}}</div>
+                                    <div class="header c{{ category_color_idx }} subheader">{{ name}}</div>
                                     <div class="header header-background">
                                         {{ result }} ({{ subcrates|length }})
                                     </div>

--- a/tests/minicrater/blacklist/full.html.context.expected.json
+++ b/tests/minicrater/blacklist/full.html.context.expected.json
@@ -2,9 +2,11 @@
   "categories": [
     [
       "skipped",
+      0,
       {
         "Plain": [
           {
+            "color_idx": 0,
             "name": "build-fail (local)",
             "res": "skipped",
             "runs": [
@@ -18,19 +20,23 @@
     ],
     [
       "test-pass",
+      1,
       {
         "Plain": [
           {
+            "color_idx": 1,
             "name": "build-pass (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 3,
                 "log": "stable/local/build-pass",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 3,
                 "log": "beta/local/build-pass",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
@@ -40,19 +46,23 @@
     ],
     [
       "test-skipped",
+      2,
       {
         "Plain": [
           {
+            "color_idx": 2,
             "name": "test-fail (local)",
             "res": "test-skipped",
             "runs": [
               {
+                "color_idx": 3,
                 "log": "stable/local/test-fail",
-                "res": 1
+                "name_idx": 1
               },
               {
+                "color_idx": 3,
                 "log": "beta/local/test-fail",
-                "res": 1
+                "name_idx": 1
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
@@ -61,23 +71,26 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "skipped": {
+  "colors": [
+    {
       "Striped": [
         "#494b4a",
         "#555555"
       ]
     },
-    "test-pass": {
+    {
       "Single": "#72a156"
     },
-    "test-skipped": {
+    {
       "Striped": [
         "#72a156",
         "#80b65f"
       ]
+    },
+    {
+      "Single": "#62a156"
     }
-  },
+  ],
   "crates_count": 3,
   "full": true,
   "info": {
@@ -100,14 +113,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#62a156"
     }
   ],
   "result_names": [

--- a/tests/minicrater/blacklist/index.html.context.expected.json
+++ b/tests/minicrater/blacklist/index.html.context.expected.json
@@ -1,6 +1,22 @@
 {
   "categories": [],
-  "comparison_colors": {},
+  "colors": [
+    {
+      "Striped": [
+        "#494b4a",
+        "#555555"
+      ]
+    },
+    {
+      "Single": "#72a156"
+    },
+    {
+      "Striped": [
+        "#72a156",
+        "#80b65f"
+      ]
+    }
+  ],
   "crates_count": 3,
   "full": false,
   "info": {
@@ -25,6 +41,5 @@
       "url": "downloads.html"
     }
   ],
-  "result_colors": [],
   "result_names": []
 }

--- a/tests/minicrater/clippy/full.html.context.expected.json
+++ b/tests/minicrater/clippy/full.html.context.expected.json
@@ -2,19 +2,23 @@
   "categories": [
     [
       "test-pass",
+      0,
       {
         "Plain": [
           {
+            "color_idx": 0,
             "name": "build-pass (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 2,
                 "log": "stable/local/build-pass",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 2,
                 "log": "stable%2Brustflags=-Dclippy::all/local/build-pass",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
@@ -24,6 +28,7 @@
     ],
     [
       "regressed",
+      1,
       {
         "Tree": {
           "count": 0,
@@ -33,22 +38,26 @@
     ],
     [
       "regressed",
+      1,
       {
         "RootResults": {
           "count": 1,
           "results": {
             "build compiler-error(clippy::print_with_newline)": [
               {
+                "color_idx": 1,
                 "name": "clippy-warn (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 2,
                     "log": "stable/local/clippy-warn",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 1,
                     "log": "stable%2Brustflags=-Dclippy::all/local/clippy-warn",
-                    "res": 1
+                    "name_idx": 1
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
@@ -59,14 +68,17 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "regressed": {
+  "colors": [
+    {
+      "Single": "#72a156"
+    },
+    {
       "Single": "#db3026"
     },
-    "test-pass": {
-      "Single": "#72a156"
+    {
+      "Single": "#62a156"
     }
-  },
+  ],
   "crates_count": 2,
   "full": true,
   "info": {
@@ -88,14 +100,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#db3026"
     }
   ],
   "result_names": [

--- a/tests/minicrater/clippy/index.html.context.expected.json
+++ b/tests/minicrater/clippy/index.html.context.expected.json
@@ -2,6 +2,7 @@
   "categories": [
     [
       "regressed",
+      1,
       {
         "Tree": {
           "count": 0,
@@ -11,22 +12,26 @@
     ],
     [
       "regressed",
+      1,
       {
         "RootResults": {
           "count": 1,
           "results": {
             "build compiler-error(clippy::print_with_newline)": [
               {
+                "color_idx": 1,
                 "name": "clippy-warn (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 2,
                     "log": "stable/local/clippy-warn",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 1,
                     "log": "stable%2Brustflags=-Dclippy::all/local/clippy-warn",
-                    "res": 1
+                    "name_idx": 1
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
@@ -37,11 +42,17 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "regressed": {
+  "colors": [
+    {
+      "Single": "#72a156"
+    },
+    {
       "Single": "#db3026"
+    },
+    {
+      "Single": "#62a156"
     }
-  },
+  ],
   "crates_count": 2,
   "full": false,
   "info": {
@@ -63,14 +74,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#db3026"
     }
   ],
   "result_names": [

--- a/tests/minicrater/doc/full.html.context.expected.json
+++ b/tests/minicrater/doc/full.html.context.expected.json
@@ -2,19 +2,23 @@
   "categories": [
     [
       "test-pass",
+      0,
       {
         "Plain": [
           {
+            "color_idx": 0,
             "name": "build-pass (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 2,
                 "log": "stable/local/build-pass",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 2,
                 "log": "beta/local/build-pass",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
@@ -24,19 +28,23 @@
     ],
     [
       "build-fail",
+      1,
       {
         "Plain": [
           {
+            "color_idx": 1,
             "name": "docs-rs-features (local)",
             "res": "build-fail",
             "runs": [
               {
+                "color_idx": 3,
                 "log": "stable/local/docs-rs-features",
-                "res": 1
+                "name_idx": 1
               },
               {
+                "color_idx": 3,
                 "log": "beta/local/docs-rs-features",
-                "res": 1
+                "name_idx": 1
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/docs-rs-features"
@@ -45,14 +53,20 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "build-fail": {
+  "colors": [
+    {
+      "Single": "#72a156"
+    },
+    {
       "Single": "#65461e"
     },
-    "test-pass": {
-      "Single": "#72a156"
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
     }
-  },
+  ],
   "crates_count": 2,
   "full": true,
   "info": {
@@ -74,14 +88,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#db3026"
     }
   ],
   "result_names": [

--- a/tests/minicrater/doc/index.html.context.expected.json
+++ b/tests/minicrater/doc/index.html.context.expected.json
@@ -1,6 +1,13 @@
 {
   "categories": [],
-  "comparison_colors": {},
+  "colors": [
+    {
+      "Single": "#72a156"
+    },
+    {
+      "Single": "#65461e"
+    }
+  ],
   "crates_count": 2,
   "full": false,
   "info": {
@@ -24,6 +31,5 @@
       "url": "downloads.html"
     }
   ],
-  "result_colors": [],
   "result_names": []
 }

--- a/tests/minicrater/full/full.html.context.expected.json
+++ b/tests/minicrater/full/full.html.context.expected.json
@@ -2,22 +2,26 @@
   "categories": [
     [
       "regressed",
+      0,
       {
         "Tree": {
           "count": 1,
           "tree": {
             "rust-lang/crater/f190933e896443e285e3bb6962fb87d7439b8d65": [
               {
+                "color_idx": 0,
                 "name": "beta-faulty-deps (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 7,
                     "log": "stable/local/beta-faulty-deps",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/beta-faulty-deps",
-                    "res": 1
+                    "name_idx": 1
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
@@ -29,22 +33,26 @@
     ],
     [
       "regressed",
+      0,
       {
         "RootResults": {
           "count": 4,
           "results": {
             "build ICE": [
               {
+                "color_idx": 0,
                 "name": "ice-regression (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 0,
                     "log": "stable/local/ice-regression",
-                    "res": 4
+                    "name_idx": 3
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/ice-regression",
-                    "res": 5
+                    "name_idx": 4
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/ice-regression"
@@ -52,16 +60,19 @@
             ],
             "build compiler-error(E0013)": [
               {
+                "color_idx": 0,
                 "name": "error-code (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 7,
                     "log": "stable/local/error-code",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/error-code",
-                    "res": 3
+                    "name_idx": 3
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
@@ -69,16 +80,19 @@
             ],
             "build compiler-error(E0015)": [
               {
+                "color_idx": 0,
                 "name": "error-code (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 7,
                     "log": "stable/local/error-code",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/error-code",
-                    "res": 3
+                    "name_idx": 3
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
@@ -86,16 +100,19 @@
             ],
             "build failed (unknown)": [
               {
+                "color_idx": 0,
                 "name": "beta-regression (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 7,
                     "log": "stable/local/beta-regression",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/beta-regression",
-                    "res": 2
+                    "name_idx": 2
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
@@ -107,6 +124,7 @@
     ],
     [
       "fixed",
+      1,
       {
         "Tree": {
           "count": 0,
@@ -116,37 +134,44 @@
     ],
     [
       "fixed",
+      1,
       {
         "RootResults": {
           "count": 1,
           "results": {
             "build failed (unknown)": [
               {
+                "color_idx": 1,
                 "name": "beta-fixed (local)",
                 "res": "fixed",
                 "runs": [
                   {
+                    "color_idx": 0,
                     "log": "stable/local/beta-fixed",
-                    "res": 2
+                    "name_idx": 2
                   },
                   {
+                    "color_idx": 7,
                     "log": "beta/local/beta-fixed",
-                    "res": 0
+                    "name_idx": 0
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-fixed"
               },
               {
+                "color_idx": 1,
                 "name": "network-access (local)",
                 "res": "fixed",
                 "runs": [
                   {
+                    "color_idx": 0,
                     "log": "stable/local/network-access",
-                    "res": 2
+                    "name_idx": 2
                   },
                   {
+                    "color_idx": 3,
                     "log": "beta/local/network-access",
-                    "res": 6
+                    "name_idx": 5
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/network-access"
@@ -158,34 +183,41 @@
     ],
     [
       "broken",
+      2,
       {
         "Plain": [
           {
+            "color_idx": 2,
             "name": "broken-cargotoml (local)",
             "res": "broken",
             "runs": [
               {
+                "color_idx": 2,
                 "log": "stable/local/broken-cargotoml",
-                "res": 7
+                "name_idx": 6
               },
               {
+                "color_idx": 2,
                 "log": "beta/local/broken-cargotoml",
-                "res": 7
+                "name_idx": 6
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/broken-cargotoml"
           },
           {
+            "color_idx": 2,
             "name": "yanked-deps (local)",
             "res": "broken",
             "runs": [
               {
+                "color_idx": 2,
                 "log": "stable/local/yanked-deps",
-                "res": 8
+                "name_idx": 7
               },
               {
+                "color_idx": 2,
                 "log": "beta/local/yanked-deps",
-                "res": 8
+                "name_idx": 7
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/yanked-deps"
@@ -195,34 +227,41 @@
     ],
     [
       "build-fail",
+      3,
       {
         "Plain": [
           {
+            "color_idx": 3,
             "name": "build-fail (local)",
             "res": "build-fail",
             "runs": [
               {
+                "color_idx": 0,
                 "log": "stable/local/build-fail",
-                "res": 2
+                "name_idx": 2
               },
               {
+                "color_idx": 0,
                 "log": "beta/local/build-fail",
-                "res": 2
+                "name_idx": 2
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
           },
           {
+            "color_idx": 3,
             "name": "faulty-deps (local)",
             "res": "build-fail",
             "runs": [
               {
+                "color_idx": 0,
                 "log": "stable/local/faulty-deps",
-                "res": 9
+                "name_idx": 1
               },
               {
+                "color_idx": 0,
                 "log": "beta/local/faulty-deps",
-                "res": 9
+                "name_idx": 1
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/faulty-deps"
@@ -232,79 +271,95 @@
     ],
     [
       "test-pass",
+      4,
       {
         "Plain": [
           {
+            "color_idx": 4,
             "name": "build-pass (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 7,
                 "log": "stable/local/build-pass",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 7,
                 "log": "beta/local/build-pass",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
           },
           {
+            "color_idx": 4,
             "name": "clippy-warn (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 7,
                 "log": "stable/local/clippy-warn",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 7,
                 "log": "beta/local/clippy-warn",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/clippy-warn"
           },
           {
+            "color_idx": 4,
             "name": "docs-rs-features (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 7,
                 "log": "stable/local/docs-rs-features",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 7,
                 "log": "beta/local/docs-rs-features",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/docs-rs-features"
           },
           {
+            "color_idx": 4,
             "name": "missing-examples (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 7,
                 "log": "stable/local/missing-examples",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 7,
                 "log": "beta/local/missing-examples",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/missing-examples"
           },
           {
+            "color_idx": 4,
             "name": "outdated-lockfile (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 7,
                 "log": "stable/local/outdated-lockfile",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 7,
                 "log": "beta/local/outdated-lockfile",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/outdated-lockfile"
@@ -314,9 +369,11 @@
     ],
     [
       "skipped",
+      5,
       {
         "Plain": [
           {
+            "color_idx": 5,
             "name": "memory-hungry (local)",
             "res": "skipped",
             "runs": [
@@ -330,19 +387,23 @@
     ],
     [
       "test-fail",
+      6,
       {
         "Plain": [
           {
+            "color_idx": 6,
             "name": "test-fail (local)",
             "res": "test-fail",
             "runs": [
               {
+                "color_idx": 3,
                 "log": "stable/local/test-fail",
-                "res": 6
+                "name_idx": 5
               },
               {
+                "color_idx": 3,
                 "log": "beta/local/test-fail",
-                "res": 6
+                "name_idx": 5
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
@@ -351,32 +412,35 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "broken": {
-      "Single": "#44176e"
-    },
-    "build-fail": {
-      "Single": "#65461e"
-    },
-    "fixed": {
-      "Single": "#5630db"
-    },
-    "regressed": {
+  "colors": [
+    {
       "Single": "#db3026"
     },
-    "skipped": {
+    {
+      "Single": "#5630db"
+    },
+    {
+      "Single": "#44176e"
+    },
+    {
+      "Single": "#65461e"
+    },
+    {
+      "Single": "#72a156"
+    },
+    {
       "Striped": [
         "#494b4a",
         "#555555"
       ]
     },
-    "test-fail": {
+    {
       "Single": "#788843"
     },
-    "test-pass": {
-      "Single": "#72a156"
+    {
+      "Single": "#62a156"
     }
-  },
+  ],
   "crates_count": 17,
   "full": true,
   "info": {
@@ -405,48 +469,14 @@
       "url": "downloads.html"
     }
   ],
-  "result_colors": [
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#65461e"
-    },
-    {
-      "Single": "#44176e"
-    },
-    {
-      "Single": "#44176e"
-    },
-    {
-      "Single": "#db3026"
-    }
-  ],
   "result_names": [
     "test passed",
     "build faulty deps",
     "build failed (unknown)",
     "build compiler error",
-    "build compiler error",
     "build ICE",
     "test failed (unknown)",
     "broken Cargo.toml",
-    "deps yanked",
-    "build faulty deps"
+    "deps yanked"
   ]
 }

--- a/tests/minicrater/full/index.html.context.expected.json
+++ b/tests/minicrater/full/index.html.context.expected.json
@@ -2,22 +2,26 @@
   "categories": [
     [
       "regressed",
+      0,
       {
         "Tree": {
           "count": 1,
           "tree": {
             "rust-lang/crater/f190933e896443e285e3bb6962fb87d7439b8d65": [
               {
+                "color_idx": 0,
                 "name": "beta-faulty-deps (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 7,
                     "log": "stable/local/beta-faulty-deps",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/beta-faulty-deps",
-                    "res": 1
+                    "name_idx": 1
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
@@ -29,22 +33,26 @@
     ],
     [
       "regressed",
+      0,
       {
         "RootResults": {
           "count": 4,
           "results": {
             "build ICE": [
               {
+                "color_idx": 0,
                 "name": "ice-regression (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 0,
                     "log": "stable/local/ice-regression",
-                    "res": 4
+                    "name_idx": 3
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/ice-regression",
-                    "res": 5
+                    "name_idx": 4
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/ice-regression"
@@ -52,16 +60,19 @@
             ],
             "build compiler-error(E0013)": [
               {
+                "color_idx": 0,
                 "name": "error-code (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 7,
                     "log": "stable/local/error-code",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/error-code",
-                    "res": 3
+                    "name_idx": 3
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
@@ -69,16 +80,19 @@
             ],
             "build compiler-error(E0015)": [
               {
+                "color_idx": 0,
                 "name": "error-code (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 7,
                     "log": "stable/local/error-code",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/error-code",
-                    "res": 3
+                    "name_idx": 3
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
@@ -86,16 +100,19 @@
             ],
             "build failed (unknown)": [
               {
+                "color_idx": 0,
                 "name": "beta-regression (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 7,
                     "log": "stable/local/beta-regression",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/beta-regression",
-                    "res": 2
+                    "name_idx": 2
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
@@ -107,6 +124,7 @@
     ],
     [
       "fixed",
+      1,
       {
         "Tree": {
           "count": 0,
@@ -116,37 +134,44 @@
     ],
     [
       "fixed",
+      1,
       {
         "RootResults": {
           "count": 1,
           "results": {
             "build failed (unknown)": [
               {
+                "color_idx": 1,
                 "name": "beta-fixed (local)",
                 "res": "fixed",
                 "runs": [
                   {
+                    "color_idx": 0,
                     "log": "stable/local/beta-fixed",
-                    "res": 2
+                    "name_idx": 2
                   },
                   {
+                    "color_idx": 7,
                     "log": "beta/local/beta-fixed",
-                    "res": 0
+                    "name_idx": 0
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-fixed"
               },
               {
+                "color_idx": 1,
                 "name": "network-access (local)",
                 "res": "fixed",
                 "runs": [
                   {
+                    "color_idx": 0,
                     "log": "stable/local/network-access",
-                    "res": 2
+                    "name_idx": 2
                   },
                   {
+                    "color_idx": 3,
                     "log": "beta/local/network-access",
-                    "res": 6
+                    "name_idx": 5
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/network-access"
@@ -157,14 +182,35 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "fixed": {
+  "colors": [
+    {
+      "Single": "#db3026"
+    },
+    {
       "Single": "#5630db"
     },
-    "regressed": {
-      "Single": "#db3026"
+    {
+      "Single": "#44176e"
+    },
+    {
+      "Single": "#65461e"
+    },
+    {
+      "Single": "#72a156"
+    },
+    {
+      "Striped": [
+        "#494b4a",
+        "#555555"
+      ]
+    },
+    {
+      "Single": "#788843"
+    },
+    {
+      "Single": "#62a156"
     }
-  },
+  ],
   "crates_count": 17,
   "full": false,
   "info": {
@@ -193,34 +239,10 @@
       "url": "downloads.html"
     }
   ],
-  "result_colors": [
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#65461e"
-    }
-  ],
   "result_names": [
     "test passed",
     "build faulty deps",
     "build failed (unknown)",
-    "build compiler error",
     "build compiler error",
     "build ICE",
     "test failed (unknown)"

--- a/tests/minicrater/ignore-blacklist/full.html.context.expected.json
+++ b/tests/minicrater/ignore-blacklist/full.html.context.expected.json
@@ -2,19 +2,23 @@
   "categories": [
     [
       "build-fail",
+      0,
       {
         "Plain": [
           {
+            "color_idx": 0,
             "name": "build-fail (local)",
             "res": "build-fail",
             "runs": [
               {
+                "color_idx": 3,
                 "log": "stable/local/build-fail",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 3,
                 "log": "beta/local/build-fail",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
@@ -24,19 +28,23 @@
     ],
     [
       "test-pass",
+      1,
       {
         "Plain": [
           {
+            "color_idx": 1,
             "name": "build-pass (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 4,
                 "log": "stable/local/build-pass",
-                "res": 1
+                "name_idx": 1
               },
               {
+                "color_idx": 4,
                 "log": "beta/local/build-pass",
-                "res": 1
+                "name_idx": 1
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
@@ -46,19 +54,23 @@
     ],
     [
       "test-fail",
+      2,
       {
         "Plain": [
           {
+            "color_idx": 2,
             "name": "test-fail (local)",
             "res": "test-fail",
             "runs": [
               {
+                "color_idx": 0,
                 "log": "stable/local/test-fail",
-                "res": 2
+                "name_idx": 2
               },
               {
+                "color_idx": 0,
                 "log": "beta/local/test-fail",
-                "res": 2
+                "name_idx": 2
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
@@ -67,17 +79,23 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "build-fail": {
+  "colors": [
+    {
       "Single": "#65461e"
     },
-    "test-fail": {
+    {
+      "Single": "#72a156"
+    },
+    {
       "Single": "#788843"
     },
-    "test-pass": {
-      "Single": "#72a156"
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#62a156"
     }
-  },
+  ],
   "crates_count": 3,
   "full": true,
   "info": {
@@ -100,17 +118,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#65461e"
     }
   ],
   "result_names": [

--- a/tests/minicrater/ignore-blacklist/index.html.context.expected.json
+++ b/tests/minicrater/ignore-blacklist/index.html.context.expected.json
@@ -1,6 +1,16 @@
 {
   "categories": [],
-  "comparison_colors": {},
+  "colors": [
+    {
+      "Single": "#65461e"
+    },
+    {
+      "Single": "#72a156"
+    },
+    {
+      "Single": "#788843"
+    }
+  ],
   "crates_count": 3,
   "full": false,
   "info": {
@@ -25,6 +35,5 @@
       "url": "downloads.html"
     }
   ],
-  "result_colors": [],
   "result_names": []
 }

--- a/tests/minicrater/missing-repo/full.html.context.expected.json
+++ b/tests/minicrater/missing-repo/full.html.context.expected.json
@@ -2,19 +2,23 @@
   "categories": [
     [
       "broken",
+      0,
       {
         "Plain": [
           {
+            "color_idx": 0,
             "name": "ghost.missing",
             "res": "broken",
             "runs": [
               {
+                "color_idx": 0,
                 "log": "stable/gh/ghost.missing",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 0,
                 "log": "beta/gh/ghost.missing",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/ghost/missing"
@@ -23,11 +27,11 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "broken": {
+  "colors": [
+    {
       "Single": "#44176e"
     }
-  },
+  ],
   "crates_count": 1,
   "full": true,
   "info": {
@@ -48,11 +52,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#44176e"
     }
   ],
   "result_names": [

--- a/tests/minicrater/missing-repo/index.html.context.expected.json
+++ b/tests/minicrater/missing-repo/index.html.context.expected.json
@@ -1,6 +1,10 @@
 {
   "categories": [],
-  "comparison_colors": {},
+  "colors": [
+    {
+      "Single": "#44176e"
+    }
+  ],
   "crates_count": 1,
   "full": false,
   "info": {
@@ -23,6 +27,5 @@
       "url": "downloads.html"
     }
   ],
-  "result_colors": [],
   "result_names": []
 }

--- a/tests/minicrater/resource-exhaustion/full.html.context.expected.json
+++ b/tests/minicrater/resource-exhaustion/full.html.context.expected.json
@@ -2,19 +2,23 @@
   "categories": [
     [
       "test-pass",
+      0,
       {
         "Plain": [
           {
+            "color_idx": 0,
             "name": "build-pass (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 2,
                 "log": "stable/local/build-pass",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 2,
                 "log": "beta/local/build-pass",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
@@ -24,19 +28,23 @@
     ],
     [
       "spurious-fixed",
+      1,
       {
         "Plain": [
           {
+            "color_idx": 1,
             "name": "memory-hungry (local)",
             "res": "spurious-fixed",
             "runs": [
               {
+                "color_idx": 3,
                 "log": "stable/local/memory-hungry",
-                "res": 1
+                "name_idx": 1
               },
               {
+                "color_idx": 4,
                 "log": "beta/local/memory-hungry",
-                "res": 2
+                "name_idx": 2
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
@@ -45,17 +53,26 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "spurious-fixed": {
+  "colors": [
+    {
+      "Single": "#72a156"
+    },
+    {
       "Striped": [
         "#5630db",
         "#5d3dcf"
       ]
     },
-    "test-pass": {
-      "Single": "#72a156"
+    {
+      "Single": "#62a156"
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#65461e"
     }
-  },
+  ],
   "crates_count": 2,
   "full": true,
   "info": {
@@ -77,17 +94,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#65461e"
     }
   ],
   "result_names": [

--- a/tests/minicrater/resource-exhaustion/index.html.context.expected.json
+++ b/tests/minicrater/resource-exhaustion/index.html.context.expected.json
@@ -2,19 +2,23 @@
   "categories": [
     [
       "spurious-fixed",
+      1,
       {
         "Plain": [
           {
+            "color_idx": 1,
             "name": "memory-hungry (local)",
             "res": "spurious-fixed",
             "runs": [
               {
+                "color_idx": 2,
                 "log": "stable/local/memory-hungry",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 3,
                 "log": "beta/local/memory-hungry",
-                "res": 1
+                "name_idx": 1
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/memory-hungry"
@@ -23,14 +27,23 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "spurious-fixed": {
+  "colors": [
+    {
+      "Single": "#72a156"
+    },
+    {
       "Striped": [
         "#5630db",
         "#5d3dcf"
       ]
+    },
+    {
+      "Single": "#db3026"
+    },
+    {
+      "Single": "#65461e"
     }
-  },
+  ],
   "crates_count": 2,
   "full": false,
   "info": {
@@ -52,14 +65,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#db3026"
-    },
-    {
-      "Single": "#65461e"
     }
   ],
   "result_names": [

--- a/tests/minicrater/small/full.html.context.expected.json
+++ b/tests/minicrater/small/full.html.context.expected.json
@@ -2,6 +2,7 @@
   "categories": [
     [
       "regressed",
+      0,
       {
         "Tree": {
           "count": 0,
@@ -11,22 +12,26 @@
     ],
     [
       "regressed",
+      0,
       {
         "RootResults": {
           "count": 1,
           "results": {
             "build failed (unknown)": [
               {
+                "color_idx": 0,
                 "name": "beta-regression (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 2,
                     "log": "stable/local/beta-regression",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/beta-regression",
-                    "res": 1
+                    "name_idx": 1
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
@@ -38,19 +43,23 @@
     ],
     [
       "test-pass",
+      1,
       {
         "Plain": [
           {
+            "color_idx": 1,
             "name": "build-pass (local)",
             "res": "test-pass",
             "runs": [
               {
+                "color_idx": 2,
                 "log": "stable/local/build-pass",
-                "res": 0
+                "name_idx": 0
               },
               {
+                "color_idx": 2,
                 "log": "beta/local/build-pass",
-                "res": 0
+                "name_idx": 0
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-pass"
@@ -59,14 +68,17 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "regressed": {
+  "colors": [
+    {
       "Single": "#db3026"
     },
-    "test-pass": {
+    {
       "Single": "#72a156"
+    },
+    {
+      "Single": "#62a156"
     }
-  },
+  ],
   "crates_count": 2,
   "full": true,
   "info": {
@@ -88,14 +100,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#db3026"
     }
   ],
   "result_names": [

--- a/tests/minicrater/small/index.html.context.expected.json
+++ b/tests/minicrater/small/index.html.context.expected.json
@@ -2,6 +2,7 @@
   "categories": [
     [
       "regressed",
+      0,
       {
         "Tree": {
           "count": 0,
@@ -11,22 +12,26 @@
     ],
     [
       "regressed",
+      0,
       {
         "RootResults": {
           "count": 1,
           "results": {
             "build failed (unknown)": [
               {
+                "color_idx": 0,
                 "name": "beta-regression (local)",
                 "res": "regressed",
                 "runs": [
                   {
+                    "color_idx": 2,
                     "log": "stable/local/beta-regression",
-                    "res": 0
+                    "name_idx": 0
                   },
                   {
+                    "color_idx": 0,
                     "log": "beta/local/beta-regression",
-                    "res": 1
+                    "name_idx": 1
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
@@ -37,11 +42,17 @@
       }
     ]
   ],
-  "comparison_colors": {
-    "regressed": {
+  "colors": [
+    {
       "Single": "#db3026"
+    },
+    {
+      "Single": "#72a156"
+    },
+    {
+      "Single": "#62a156"
     }
-  },
+  ],
   "crates_count": 2,
   "full": false,
   "info": {
@@ -63,14 +74,6 @@
       "active": false,
       "label": "Downloads",
       "url": "downloads.html"
-    }
-  ],
-  "result_colors": [
-    {
-      "Single": "#62a156"
-    },
-    {
-      "Single": "#db3026"
     }
   ],
   "result_names": [


### PR DESCRIPTION
Tested locally on a sample report that the results look visually the same.