### PR TITLE
zstd-compress archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "url 2.4.1",
  "walkdir",
  "warp",
+ "zstd",
 ]
 
 [[package]]
@@ -4737,3 +4738,31 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zstd"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ docsrs-metadata = { git = "https://github.com/rust-lang/docs.rs/" }
 dotenv = "0.15"
 failure = "0.1.3"
 flate2 = "1"
+zstd = "0.13.0"
 http = "0.2"
 hyper = "0.14"
 lazy_static = "1.0"

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -243,9 +243,9 @@ pub fn generate_report<DB: ReadResults>(
                 })
             });
             // Convert errors to Nones
-            let mut crate_results = crate_results.map(|r| r.ok()).collect::<Vec<_>>();
-            let crate2 = crate_results.pop().unwrap();
-            let crate1 = crate_results.pop().unwrap();
+            let mut crate_results = crate_results.map(|r| r.ok());
+            let crate1 = crate_results.next().unwrap();
+            let crate2 = crate_results.next().unwrap();
             let comp = compare(
                 config,
                 krate,

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -125,18 +125,20 @@ macro_rules! test_result_enum {
 
             fn from_str(input: &str) -> Fallible<Self> {
                 // if there is more than one ':' we assume it's part of a failure reason serialization
-                let parts: Vec<&str> = input.splitn(2, ':').collect();
+                let mut parts = input.splitn(2, ':');
+                let part1 = parts.next().unwrap();
+                let part2 = parts.next();
 
-                if parts.len() == 1 {
-                    match parts[0] {
+                if part2.is_none() {
+                    match part1 {
                         $($with_reason_repr => Ok($name::$with_reason_name($reason::Unknown)),)*
                         $($reasonless_repr => Ok($name::$reasonless_name),)*
                         other => Err(TestResultParseError::UnknownResult(other.into()).into()),
                     }
                 } else {
-                    match parts[0] {
+                    match part1 {
                         $($reasonless_repr => Err(TestResultParseError::UnexpectedFailureReason.into()),)*
-                        $($with_reason_repr => Ok($name::$with_reason_name(parts[1].parse()?)),)*
+                        $($with_reason_repr => Ok($name::$with_reason_name(part2.unwrap().parse()?)),)*
                         other => Err(TestResultParseError::UnknownResult(other.into()).into()),
                     }
                 }

--- a/templates/report/downloads.html
+++ b/templates/report/downloads.html
@@ -14,7 +14,7 @@
 
     <div class="category">
         <div class="header header-background toggle" data-toggle="#downloads-archives">
-            Build logs (tar.gz)
+            Build logs (tar.zst)
         </div>
         <div class="crates" id="downloads-archives">
             {% for archive in available_archives %}

--- a/tests/minicrater/blacklist/downloads.html.context.expected.json
+++ b/tests/minicrater/blacklist/downloads.html.context.expected.json
@@ -2,15 +2,15 @@
   "available_archives": [
     {
       "name": "All the crates",
-      "path": "logs-archives/all.tar.gz"
+      "path": "logs-archives/all.tar.zst"
     },
     {
       "name": "test-pass crates",
-      "path": "logs-archives/test-pass.tar.gz"
+      "path": "logs-archives/test-pass.tar.zst"
     },
     {
       "name": "test-skipped crates",
-      "path": "logs-archives/test-skipped.tar.gz"
+      "path": "logs-archives/test-skipped.tar.zst"
     }
   ],
   "crates_count": 3,

--- a/tests/minicrater/clippy/downloads.html.context.expected.json
+++ b/tests/minicrater/clippy/downloads.html.context.expected.json
@@ -2,15 +2,15 @@
   "available_archives": [
     {
       "name": "All the crates",
-      "path": "logs-archives/all.tar.gz"
+      "path": "logs-archives/all.tar.zst"
     },
     {
       "name": "test-pass crates",
-      "path": "logs-archives/test-pass.tar.gz"
+      "path": "logs-archives/test-pass.tar.zst"
     },
     {
       "name": "regressed crates",
-      "path": "logs-archives/regressed.tar.gz"
+      "path": "logs-archives/regressed.tar.zst"
     }
   ],
   "crates_count": 2,

--- a/tests/minicrater/doc/downloads.html.context.expected.json
+++ b/tests/minicrater/doc/downloads.html.context.expected.json
@@ -2,15 +2,15 @@
   "available_archives": [
     {
       "name": "All the crates",
-      "path": "logs-archives/all.tar.gz"
+      "path": "logs-archives/all.tar.zst"
     },
     {
       "name": "test-pass crates",
-      "path": "logs-archives/test-pass.tar.gz"
+      "path": "logs-archives/test-pass.tar.zst"
     },
     {
       "name": "build-fail crates",
-      "path": "logs-archives/build-fail.tar.gz"
+      "path": "logs-archives/build-fail.tar.zst"
     }
   ],
   "crates_count": 2,

--- a/tests/minicrater/full/downloads.html.context.expected.json
+++ b/tests/minicrater/full/downloads.html.context.expected.json
@@ -2,31 +2,31 @@
   "available_archives": [
     {
       "name": "All the crates",
-      "path": "logs-archives/all.tar.gz"
+      "path": "logs-archives/all.tar.zst"
     },
     {
       "name": "regressed crates",
-      "path": "logs-archives/regressed.tar.gz"
+      "path": "logs-archives/regressed.tar.zst"
     },
     {
       "name": "fixed crates",
-      "path": "logs-archives/fixed.tar.gz"
+      "path": "logs-archives/fixed.tar.zst"
     },
     {
       "name": "broken crates",
-      "path": "logs-archives/broken.tar.gz"
+      "path": "logs-archives/broken.tar.zst"
     },
     {
       "name": "build-fail crates",
-      "path": "logs-archives/build-fail.tar.gz"
+      "path": "logs-archives/build-fail.tar.zst"
     },
     {
       "name": "test-pass crates",
-      "path": "logs-archives/test-pass.tar.gz"
+      "path": "logs-archives/test-pass.tar.zst"
     },
     {
       "name": "test-fail crates",
-      "path": "logs-archives/test-fail.tar.gz"
+      "path": "logs-archives/test-fail.tar.zst"
     }
   ],
   "crates_count": 17,

--- a/tests/minicrater/ignore-blacklist/downloads.html.context.expected.json
+++ b/tests/minicrater/ignore-blacklist/downloads.html.context.expected.json
@@ -2,15 +2,15 @@
   "available_archives": [
     {
       "name": "All the crates",
-      "path": "logs-archives/all.tar.gz"
+      "path": "logs-archives/all.tar.zst"
     },
     {
       "name": "test-pass crates",
-      "path": "logs-archives/test-pass.tar.gz"
+      "path": "logs-archives/test-pass.tar.zst"
     },
     {
       "name": "test-fail crates",
-      "path": "logs-archives/test-fail.tar.gz"
+      "path": "logs-archives/test-fail.tar.zst"
     }
   ],
   "crates_count": 3,

--- a/tests/minicrater/missing-repo/downloads.html.context.expected.json
+++ b/tests/minicrater/missing-repo/downloads.html.context.expected.json
@@ -2,11 +2,11 @@
   "available_archives": [
     {
       "name": "All the crates",
-      "path": "logs-archives/all.tar.gz"
+      "path": "logs-archives/all.tar.zst"
     },
     {
       "name": "broken crates",
-      "path": "logs-archives/broken.tar.gz"
+      "path": "logs-archives/broken.tar.zst"
     }
   ],
   "crates_count": 1,

--- a/tests/minicrater/resource-exhaustion/downloads.html.context.expected.json
+++ b/tests/minicrater/resource-exhaustion/downloads.html.context.expected.json
@@ -2,15 +2,15 @@
   "available_archives": [
     {
       "name": "All the crates",
-      "path": "logs-archives/all.tar.gz"
+      "path": "logs-archives/all.tar.zst"
     },
     {
       "name": "test-pass crates",
-      "path": "logs-archives/test-pass.tar.gz"
+      "path": "logs-archives/test-pass.tar.zst"
     },
     {
       "name": "spurious-fixed crates",
-      "path": "logs-archives/spurious-fixed.tar.gz"
+      "path": "logs-archives/spurious-fixed.tar.zst"
     }
   ],
   "crates_count": 2,

--- a/tests/minicrater/small/downloads.html.context.expected.json
+++ b/tests/minicrater/small/downloads.html.context.expected.json
@@ -2,15 +2,15 @@
   "available_archives": [
     {
       "name": "All the crates",
-      "path": "logs-archives/all.tar.gz"
+      "path": "logs-archives/all.tar.zst"
     },
     {
       "name": "regressed crates",
-      "path": "logs-archives/regressed.tar.gz"
+      "path": "logs-archives/regressed.tar.zst"
     },
     {
       "name": "test-pass crates",
-      "path": "logs-archives/test-pass.tar.gz"
+      "path": "logs-archives/test-pass.tar.zst"
     }
   ],
   "crates_count": 2,


### PR DESCRIPTION
Archives are smaller, faster to compress, and faster to decompress. Installing zstd is pretty easy on most platforms as well, on my couple systems the default system tar is able to read .tar.zst files just fine too.

It's a win for the duration of the compression though; zstd compressing the all.tar tarball takes ~12 seconds locally vs. 2 minutes with gzip (at default settings), and zstd produces a ~500MB smaller compressed result (1.2 GB -> 705MB).



