### PR TITLE
fix  build  failure caused by `stdsimd` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "crc32c"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
 dependencies = [
  "rustc_version",
 ]
@@ -4715,18 +4715,18 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.18"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7d7c7970ca2215b8c1ccf4d4f354c4733201dfaaba72d44ae5b37472e4901"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.18"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b27b1bb92570f989aac0ab7e9cbfbacdd65973f7ee920d9f0e71ebac878fd0b"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -13,7 +13,6 @@ use crate::utils::disk_usage::DiskUsage;
 use failure::Error;
 use rustwide::Workspace;
 use std::collections::BTreeSet;
-use std::iter::FromIterator;
 use std::ops;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use mime::{self, Mime};
+use mime:: Mime;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use mime:: Mime;
+use mime::Mime;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,7 @@ use std::time::Duration;
 pub struct Ex(String);
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct DockerEnv(String);
 impl FromStr for Ex {
     type Err = Error;

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -6,7 +6,6 @@ use crate::prelude::*;
 use cargo_metadata::PackageId;
 use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
 use rustwide::Crate as RustwideCrate;
-use std::convert::TryFrom;
 use std::fmt;
 use std::path::Path;
 use std::str::FromStr;

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
-use rand::{
-    distributions::{Alphanumeric, DistString},
-};
+use rand::distributions::{Alphanumeric, DistString};
 use rusqlite::{Connection, Transaction};
 use std::collections::HashSet;
 
@@ -387,7 +385,7 @@ pub fn execute(db: &mut Connection) -> Fallible<()> {
     };
 
     for &(name, ref migration) in &migrations() {
-        if !executed_migrations.contains(&name.to_string()) {
+        if !executed_migrations.contains(name) {
             let t = db.transaction()?;
             match migration {
                 MigrationKind::SQL(sql) => t.execute_batch(sql),

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use rand::{
-    self,
     distributions::{Alphanumeric, DistString},
 };
 use rusqlite::{Connection, Transaction};

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -8,12 +8,11 @@ use crate::results::{EncodedLog, EncodingType, FailureReason, ReadResults, TestR
 use crate::toolchain::Toolchain;
 use crate::utils;
 use crates_index::GitIndex;
-use mime::{self, Mime};
+use mime::Mime;
 use percent_encoding::{utf8_percent_encode, AsciiSet};
 use std::borrow::Cow;
 #[cfg(test)]
 use std::collections::HashMap;
-use std::convert::AsRef;
 use std::fmt::{self, Display};
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -13,7 +13,6 @@ use rustwide::cmd::{CommandError, ProcessLinesActions, SandboxBuilder};
 use rustwide::logging::LogStorage;
 use rustwide::{Build, PrepareError};
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::convert::TryFrom;
 
 fn failure_reason(err: &Error) -> FailureReason {
     for cause in err.iter_chain() {

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use rust_team_data::v1 as team_data;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
-use warp::{self, Filter, Rejection};
+use warp::{Filter, Rejection};
 
 lazy_static! {
     static ref GIT_REVISION_RE: Regex =

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,12 +17,12 @@ use crate::server::agents::Agents;
 use crate::server::auth::ACL;
 use crate::server::github::{GitHub, GitHubApi};
 use crate::server::tokens::{BotTokens, Tokens};
-use http::{self, header::HeaderValue, Response};
+use http::{header::HeaderValue, Response};
 use hyper::Body;
 use metrics::Metrics;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
-use warp::{self, Filter};
+use warp::Filter;
 
 lazy_static! {
     static ref SERVER_HEADER: String =

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -14,7 +14,7 @@ use hyper::Body;
 use std::collections::HashMap;
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Instant;
-use warp::{self, Filter, Rejection};
+use warp::{Filter, Rejection};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/src/server/routes/metrics.rs
+++ b/src/server/routes/metrics.rs
@@ -5,7 +5,7 @@ use http::{Response, StatusCode};
 use hyper::Body;
 use prometheus::{Encoder, TextEncoder};
 use std::sync::Arc;
-use warp::{self, Filter, Rejection};
+use warp::{Filter, Rejection};
 
 pub fn routes(
     data: Arc<Data>,

--- a/src/server/routes/ui/mod.rs
+++ b/src/server/routes/ui/mod.rs
@@ -6,7 +6,7 @@ use http::{Response, StatusCode};
 use hyper::Body;
 use serde::Serialize;
 use std::sync::Arc;
-use warp::{self, Filter, Rejection};
+use warp::{Filter, Rejection};
 
 mod agents;
 mod experiments;

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -1,6 +1,5 @@
 use crate::experiments::{Assignee, CapLints, DeferredCrateSelect, Mode};
 use crate::toolchain::Toolchain;
-use failure::{self, Fallible};
 
 #[derive(Debug, thiserror::Error)]
 #[cfg_attr(test, derive(PartialEq, Eq))]

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -12,7 +12,7 @@ use http::{HeaderMap, Response, StatusCode};
 use hyper::Body;
 use std::str::FromStr;
 use std::sync::Arc;
-use warp::{self, Filter, Rejection};
+use warp::{Filter, Rejection};
 
 fn process_webhook(
     payload: &[u8],

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use failure::{AsFail, Backtrace, Fail};
+use failure::{AsFail, Backtrace};
 use percent_encoding::{AsciiSet, CONTROLS};
 use std::any::Any;
 use std::fmt;

--- a/src/utils/serialize.rs
+++ b/src/utils/serialize.rs
@@ -1,6 +1,5 @@
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 
-
 pub fn to_vec<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/src/utils/serialize.rs
+++ b/src/utils/serialize.rs
@@ -1,5 +1,5 @@
 use serde::ser::{Serialize, SerializeSeq, Serializer};
-use std::iter::IntoIterator;
+
 
 pub fn to_vec<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
 where


### PR DESCRIPTION
I try to build a `crater` service in our CI pipeline, and when I try to compile crater,  error occurs:

```
error[E0635]: unknown feature `stdsimd`
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.6/src/lib.rs:99:42
   |
99 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
   |                                          ^^^^^^^

For more information about this error, try `rustc --explain E0635`.
error: could not compile `ahash` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```
my rust verion is 
```
rustc 1.78.0-nightly (3cbb93223 2024-03-13)
``` ,

I think this failure is caused by  the remove of `stdsimd` feature and the `ahash` package has already updated to fix it : https://github.com/tkaitchuck/aHash/pull/183

I run `cargo update -p ahash` to slove this and seems `crc32c`  has the similar problem
```
error[E0635]: unknown feature `stdsimd`
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/crc32c-0.6.4/src/lib.rs:23:30
   |
23 | #![cfg_attr(nightly, feature(stdsimd))]
   |                              ^^^^^^^

For more information about this error, try `rustc --explain E0635`.
error: could not compile `crc32c` (lib) due to 1 previous error
```
after I run `cargo update -p crc32c`, the complie process is OK

this PR update the Cargo.lock to fix this issue

