### PR TITLE
prioritize `NoSpace` error more

### DIFF
--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -409,7 +409,9 @@ fn gen_retry_list(res: &RawTestResults) -> String {
     let regressed_crates = res
         .crates
         .iter()
-        .filter(|crate_res| crate_res.res == Comparison::Regressed)
+        .filter(|crate_res| {
+            crate_res.res == Comparison::Regressed || crate_res.res == Comparison::SpuriousRegressed
+        })
         .map(|crate_res| &crate_res.krate);
 
     for krate in regressed_crates {

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -200,6 +200,8 @@ fn run_cargo<DB: WriteResults>(
         Err(e) => {
             if did_ice {
                 Err(e.context(FailureReason::ICE).into())
+            } else if ran_out_of_space {
+                Err(e.context(FailureReason::NoSpace).into())
             } else if !deps.is_empty() {
                 Err(e.context(FailureReason::DependsOn(deps)).into())
             } else if !error_codes.is_empty() {
@@ -208,8 +210,6 @@ fn run_cargo<DB: WriteResults>(
                 Err(e.context(FailureReason::NetworkAccess).into())
             } else if did_trybuild {
                 Err(e.context(FailureReason::CompilerDiagnosticChange).into())
-            } else if ran_out_of_space {
-                Err(e.context(FailureReason::NoSpace).into())
             } else {
                 Err(e.into())
             }

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -13,6 +13,7 @@ use rustwide::cmd::{CommandError, ProcessLinesActions, SandboxBuilder};
 use rustwide::logging::LogStorage;
 use rustwide::{Build, PrepareError};
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::io::ErrorKind;
 
 fn failure_reason(err: &Error) -> FailureReason {
     for cause in err.iter_chain() {
@@ -24,6 +25,36 @@ fn failure_reason(err: &Error) -> FailureReason {
             return FailureReason::Timeout;
         } else if let Some(reason) = cause.downcast_ctx::<FailureReason>() {
             return reason.clone();
+        } else if let Some(CommandError::IO(io)) = cause.downcast_ctx() {
+            match io.kind() {
+                ErrorKind::OutOfMemory => {
+                    return FailureReason::OOM;
+                }
+                _ => {
+                    // FIXME use ErrorKind once #![feature(io_error_more)] is stable <https://github.com/rust-lang/rust/issues/86442>
+                    #[cfg(target_os = "linux")]
+                    match io.raw_os_error() {
+                        // <https://mariadb.com/kb/en/operating-system-error-codes/#linux-error-codes>
+                        | Some(28) /* ErrorKind::StorageFull */
+                        | Some(122) /* ErrorKind::FilesystemQuotaExceeded */
+                        | Some(31) /* TooManyLinks */=> {
+                            return FailureReason::NoSpace
+                        }
+                        _ => {}
+                    }
+
+                    #[cfg(target_os = "windows")]
+                    match io.raw_os_error() {
+                        // <https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes>
+                        | Some(39|112) /* ErrorKind::StorageFull */
+                        | Some(1295) /* ErrorKind::FilesystemQuotaExceeded */
+                        | Some(1142) /* TooManyLinks */=> {
+                            return FailureReason::NoSpace
+                        }
+                        _ => {}
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Replacement for #715 

## adjust the prioritization of `NoSpace` 

After this it will be prioritized above
  - `DependsOn`
  - `CompilerError`
  - `NetworkAccess` 
  - `CompilerDiagnosticChange`

The later two are already spurious-regressions so only the reason will change.
The former two would previously result in a regression but now would be spurious-regressions.
I think this change is reasonable as no space will likely be the cause for the compiler error or the error in the dependency.
  
## include the spurious regressions in the `retry-regressed-list.txt` 

Spurious failures might hide actual regressions, this gives them another chance at showing actual regressions.
Further more spurious regressions are usually not too many and re-running will in a lot of cases resolve the spurious failure.

## Sort some `CommandError::IO(_)` into as better `FailureReason`
  