### PR TITLE
fix: update deprecated artifacts actions

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -88,7 +88,7 @@ jobs:
           docker save crater | gzip > /tmp/docker-images/crater.tar.gz
 
       - name: Upload the image to GitHub Actions artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docker-images
           path: /tmp/docker-images
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Download the image from GitHub Actions artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: docker-images
           path: docker-images


### PR DESCRIPTION
This action doesn't work anymore

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/3e3d2be9-a993-4429-838f-f103d350d71e">
