### PR TITLE
Reword the issue comment to use denylist instead of blacklist

### DIFF
--- a/src/server/reports.rs
+++ b/src/server/reports.rs
@@ -130,7 +130,7 @@ fn reports_thread(data: &Data, github_data: Option<&GithubData>) -> Fallible<()>
                                 "warning",
                                 format!(
                                     "If you notice any spurious failure [please add them to the \
-                                 blacklist]({}/blob/master/config.toml)!",
+                                 denylist]({}/blob/master/config.toml)!",
                                     crate::CRATER_REPO_URL,
                                 ),
                             )


### PR DESCRIPTION
Changes the comment left on github issues to read:

    ⚠️ If you notice any spurious failure [please add them to the denylist](https://github.com/rust-lang/crater/blob/master/config.toml)!

Which I think is more inclusive than the old message which referred to it as a blacklist. Conveniently, the config file in question doesn't use that term so I don't think it will be confusing to anyone trying to figure out how to drive it.

While making this change crater still uses blacklist a lot internally, but that seemed like kind of a lot for a driveby PR, but if you'd take the patch I'd be happy to switch it out.