### PR TITLE
Remove r2d2-sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,6 @@ dependencies = [
  "predicates",
  "prometheus",
  "r2d2",
- "r2d2_sqlite",
  "rand",
  "regex",
  "remove_dir_all",
@@ -3368,17 +3367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r2d2_sqlite"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f31323d6161385f385046738df520e0e8694fa74852d35891fc0be08348ddc"
-dependencies = [
- "r2d2",
- "rusqlite",
- "uuid",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4548,10 +4536,6 @@ name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
-dependencies = [
- "getrandom",
- "rand",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ lazy_static = "1.0"
 mime = "0.3.1"
 minifier = { version = "0.3", features = ["html"] }
 r2d2 = "0.8.2"
-r2d2_sqlite = "0.22.0"
 rusqlite = { version = "0.29.0", features = ["chrono", "functions", "bundled"] }
 rand = "0.8"
 regex = "1.0"


### PR DESCRIPTION
r2d2-sqlite opens connections in shared cache mode: https://github.com/ivanceras/r2d2-sqlite/blob/06aa366cfe0846e491550b7e177ca0024bf923a9/src/lib.rs#L141

Per documentation (https://www.sqlite.org/sharedcache.html#dontuse), this is discouraged. In practice the dependency is trivially replaceable anyway.