### PR TITLE
Handle parsing a PackageId that is a raw registry url into a Crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-util-schemas"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26a31f1bb58068aa01b7809533b02c26b1e64a7810ae99131da5af1a4b8e7fc2"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror",
+ "toml",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +887,7 @@ dependencies = [
  "aws-sdk-s3",
  "base64 0.21.7",
  "bytes",
+ "cargo-util-schemas",
  "cargo_metadata",
  "chrono",
  "clap",
@@ -1264,6 +1281,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -3086,6 +3113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3804,6 +3840,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2676ba99bd82f75cae5cbd2c8eda6fa0b8760f18978ea840e980dd5567b5c5b6"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4378,6 +4435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4483,6 +4546,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,13 @@ aws-sdk-s3 = "1.7"
 base64 = "0.21.5"
 bytes = "1"
 cargo_metadata = "0.18.1"
+cargo-util-schemas = "0.7.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
-crates-index = { version = "2.2.0", default-features = false, features = ["git-performance", "git-https"] }
+crates-index = { version = "2.2.0", default-features = false, features = [
+    "git-performance",
+    "git-https",
+] }
 crossbeam-channel = "0.5"
 csv = "1.0.2"
 ctrlc = "3.1.3"
@@ -46,7 +50,10 @@ remove_dir_all = "0.7"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rusqlite = { version = "0.32.1", features = ["chrono", "functions", "bundled"] }
 rust_team_data = { git = "https://github.com/rust-lang/team" }
-rustwide = { version = "0.19.0", features = ["unstable", "unstable-toolchain-ci"] }
+rustwide = { version = "0.19.0", features = [
+    "unstable",
+    "unstable-toolchain-ci",
+] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -252,6 +252,10 @@ mod tests {
                     .to_string(),
                 sha: None
             }),
+"registry+https://github.com/rust-lang/crates.io-index#cookie@0.15.0" => Crate::Registry(RegistryCrate {
+                name: "cookie".to_string(),
+                version: "0.15.0".to_string(),
+            }),
         }
 
         assert!(Crate::try_from(&PackageId {

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -114,6 +114,24 @@ impl TryFrom<&'_ PackageId> for Crate {
                     }
                 }
             }
+            ["registry", url, ..] => {
+                let Some((_registry, krate)) = url.split_once('#') else {
+                    bail!(
+                        "malformed pkgid format: {}\n maybe the representation has changed?",
+                        pkgid.repr
+                    );
+                };
+                let Some((crate_name, crate_version)) = krate.split_once('@') else {
+                    bail!(
+                        "malformed pkgid format: {}\n maybe the representation has changed?",
+                        pkgid.repr
+                    );
+                };
+                Ok(Crate::Registry(RegistryCrate {
+                    name: crate_name.to_string(),
+                    version: crate_version.to_string(),
+                }))
+            }
             _ => bail!(
                 "malformed pkgid format: {}\n maybe the representation has changed?",
                 pkgid.repr
@@ -252,7 +270,7 @@ mod tests {
                     .to_string(),
                 sha: None
             }),
-"registry+https://github.com/rust-lang/crates.io-index#cookie@0.15.0" => Crate::Registry(RegistryCrate {
+            "registry+https://github.com/rust-lang/crates.io-index#cookie@0.15.0" => Crate::Registry(RegistryCrate {
                 name: "cookie".to_string(),
                 version: "0.15.0".to_string(),
             }),

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -141,7 +141,7 @@ impl TryFrom<&'_ PackageId> for Crate {
 
                                 Ok(Crate::GitHub(GitHubRepo {
                                     org: org.to_string(),
-                                    name: repo_name.to_string(),
+                                    name: repo_name.trim_end_matches(".git").to_string(),
                                     sha: match rev {
                                         GitReference::Rev(rev)
                                             if rev.chars().all(|c| c.is_ascii_hexdigit()) =>
@@ -212,7 +212,7 @@ impl TryFrom<&'_ PackageId> for Crate {
 
                                     Ok(Crate::GitHub(GitHubRepo {
                                         org: org.to_string(),
-                                        name: repo_name.to_string(),
+                                        name: repo_name.trim_end_matches(".git").to_string(),
                                         sha: None,
                                     }))
                                 } else {

--- a/tests/minicrater/full/full.html.context.expected.json
+++ b/tests/minicrater/full/full.html.context.expected.json
@@ -5,8 +5,29 @@
       0,
       {
         "Tree": {
-          "count": 0,
-          "tree": {}
+          "count": 1,
+          "tree": {
+            "rust-lang/crater/f190933e896443e285e3bb6962fb87d7439b8d65": [
+              {
+                "color_idx": 0,
+                "name": "beta-faulty-deps (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "color_idx": 7,
+                    "log": "stable/local/beta-faulty-deps",
+                    "name_idx": 0
+                  },
+                  {
+                    "color_idx": 0,
+                    "log": "beta/local/beta-faulty-deps",
+                    "name_idx": 1
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
+              }
+            ]
+          }
         }
       }
     ],
@@ -26,12 +47,12 @@
                   {
                     "color_idx": 0,
                     "log": "stable/local/ice-regression",
-                    "name_idx": 2
+                    "name_idx": 3
                   },
                   {
                     "color_idx": 0,
                     "log": "beta/local/ice-regression",
-                    "name_idx": 3
+                    "name_idx": 4
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/ice-regression"
@@ -51,31 +72,13 @@
                   {
                     "color_idx": 0,
                     "log": "beta/local/error-code",
-                    "name_idx": 2
+                    "name_idx": 3
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
               }
             ],
             "build failed (unknown)": [
-              {
-                "color_idx": 0,
-                "name": "beta-faulty-deps (local)",
-                "res": "regressed",
-                "runs": [
-                  {
-                    "color_idx": 7,
-                    "log": "stable/local/beta-faulty-deps",
-                    "name_idx": 0
-                  },
-                  {
-                    "color_idx": 0,
-                    "log": "beta/local/beta-faulty-deps",
-                    "name_idx": 1
-                  }
-                ],
-                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
-              },
               {
                 "color_idx": 0,
                 "name": "beta-regression (local)",
@@ -89,7 +92,7 @@
                   {
                     "color_idx": 0,
                     "log": "beta/local/beta-regression",
-                    "name_idx": 1
+                    "name_idx": 2
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
@@ -125,7 +128,7 @@
                   {
                     "color_idx": 0,
                     "log": "stable/local/beta-fixed",
-                    "name_idx": 1
+                    "name_idx": 2
                   },
                   {
                     "color_idx": 7,
@@ -143,12 +146,12 @@
                   {
                     "color_idx": 0,
                     "log": "stable/local/network-access",
-                    "name_idx": 1
+                    "name_idx": 2
                   },
                   {
                     "color_idx": 3,
                     "log": "beta/local/network-access",
-                    "name_idx": 4
+                    "name_idx": 5
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/network-access"
@@ -171,12 +174,12 @@
               {
                 "color_idx": 2,
                 "log": "stable/local/broken-cargotoml",
-                "name_idx": 5
+                "name_idx": 6
               },
               {
                 "color_idx": 2,
                 "log": "beta/local/broken-cargotoml",
-                "name_idx": 5
+                "name_idx": 6
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/broken-cargotoml"
@@ -189,12 +192,12 @@
               {
                 "color_idx": 2,
                 "log": "stable/local/yanked-deps",
-                "name_idx": 6
+                "name_idx": 7
               },
               {
                 "color_idx": 2,
                 "log": "beta/local/yanked-deps",
-                "name_idx": 6
+                "name_idx": 7
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/yanked-deps"
@@ -215,12 +218,12 @@
               {
                 "color_idx": 0,
                 "log": "stable/local/build-fail",
-                "name_idx": 1
+                "name_idx": 2
               },
               {
                 "color_idx": 0,
                 "log": "beta/local/build-fail",
-                "name_idx": 1
+                "name_idx": 2
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/build-fail"
@@ -375,12 +378,12 @@
               {
                 "color_idx": 3,
                 "log": "stable/local/test-fail",
-                "name_idx": 4
+                "name_idx": 5
               },
               {
                 "color_idx": 3,
                 "log": "beta/local/test-fail",
-                "name_idx": 4
+                "name_idx": 5
               }
             ],
             "url": "https://github.com/rust-lang/crater/tree/master/local-crates/test-fail"
@@ -448,6 +451,7 @@
   ],
   "result_names": [
     "test passed",
+    "build faulty deps",
     "build failed (unknown)",
     "build compiler error",
     "build ICE",

--- a/tests/minicrater/full/index.html.context.expected.json
+++ b/tests/minicrater/full/index.html.context.expected.json
@@ -5,8 +5,29 @@
       0,
       {
         "Tree": {
-          "count": 0,
-          "tree": {}
+          "count": 1,
+          "tree": {
+            "rust-lang/crater/f190933e896443e285e3bb6962fb87d7439b8d65": [
+              {
+                "color_idx": 0,
+                "name": "beta-faulty-deps (local)",
+                "res": "regressed",
+                "runs": [
+                  {
+                    "color_idx": 7,
+                    "log": "stable/local/beta-faulty-deps",
+                    "name_idx": 0
+                  },
+                  {
+                    "color_idx": 0,
+                    "log": "beta/local/beta-faulty-deps",
+                    "name_idx": 1
+                  }
+                ],
+                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
+              }
+            ]
+          }
         }
       }
     ],
@@ -26,12 +47,12 @@
                   {
                     "color_idx": 0,
                     "log": "stable/local/ice-regression",
-                    "name_idx": 2
+                    "name_idx": 3
                   },
                   {
                     "color_idx": 0,
                     "log": "beta/local/ice-regression",
-                    "name_idx": 3
+                    "name_idx": 4
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/ice-regression"
@@ -51,31 +72,13 @@
                   {
                     "color_idx": 0,
                     "log": "beta/local/error-code",
-                    "name_idx": 2
+                    "name_idx": 3
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/error-code"
               }
             ],
             "build failed (unknown)": [
-              {
-                "color_idx": 0,
-                "name": "beta-faulty-deps (local)",
-                "res": "regressed",
-                "runs": [
-                  {
-                    "color_idx": 7,
-                    "log": "stable/local/beta-faulty-deps",
-                    "name_idx": 0
-                  },
-                  {
-                    "color_idx": 0,
-                    "log": "beta/local/beta-faulty-deps",
-                    "name_idx": 1
-                  }
-                ],
-                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
-              },
               {
                 "color_idx": 0,
                 "name": "beta-regression (local)",
@@ -89,7 +92,7 @@
                   {
                     "color_idx": 0,
                     "log": "beta/local/beta-regression",
-                    "name_idx": 1
+                    "name_idx": 2
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-regression"
@@ -125,7 +128,7 @@
                   {
                     "color_idx": 0,
                     "log": "stable/local/beta-fixed",
-                    "name_idx": 1
+                    "name_idx": 2
                   },
                   {
                     "color_idx": 7,
@@ -143,12 +146,12 @@
                   {
                     "color_idx": 0,
                     "log": "stable/local/network-access",
-                    "name_idx": 1
+                    "name_idx": 2
                   },
                   {
                     "color_idx": 3,
                     "log": "beta/local/network-access",
-                    "name_idx": 4
+                    "name_idx": 5
                   }
                 ],
                 "url": "https://github.com/rust-lang/crater/tree/master/local-crates/network-access"
@@ -218,6 +221,7 @@
   ],
   "result_names": [
     "test passed",
+    "build faulty deps",
     "build failed (unknown)",
     "build compiler error",
     "build ICE",

--- a/tests/minicrater/full/markdown.md.context.expected.json
+++ b/tests/minicrater/full/markdown.md.context.expected.json
@@ -4,29 +4,38 @@
       "regressed",
       {
         "Complete": {
-          "orphans": [],
-          "res": [
+          "orphans": [
             [
               {
-                "krate": {
-                  "Local": "beta-faulty-deps"
-                },
-                "name": "beta-faulty-deps (local)",
-                "res": "regressed",
-                "runs": [
-                  {
-                    "log": "stable/local/beta-faulty-deps",
-                    "res": "test-pass"
-                  },
-                  {
-                    "log": "beta/local/beta-faulty-deps",
-                    "res": "build-fail:unknown"
-                  }
-                ],
-                "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
+                "GitHub": {
+                  "name": "crater",
+                  "org": "rust-lang",
+                  "sha": "f190933e896443e285e3bb6962fb87d7439b8d65"
+                }
               },
-              []
-            ],
+              [
+                {
+                  "krate": {
+                    "Local": "beta-faulty-deps"
+                  },
+                  "name": "beta-faulty-deps (local)",
+                  "res": "regressed",
+                  "runs": [
+                    {
+                      "log": "stable/local/beta-faulty-deps",
+                      "res": "test-pass"
+                    },
+                    {
+                      "log": "beta/local/beta-faulty-deps",
+                      "res": "build-fail:depends-on(gh/rust-lang/crater/f190933e896443e285e3bb6962fb87d7439b8d65)"
+                    }
+                  ],
+                  "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
+                }
+              ]
+            ]
+          ],
+          "res": [
             [
               {
                 "krate": {

--- a/tests/minicrater/full/results.expected.json
+++ b/tests/minicrater/full/results.expected.json
@@ -13,7 +13,7 @@
         },
         {
           "log": "beta/local/beta-faulty-deps",
-          "res": "build-fail:unknown"
+          "res": "build-fail:depends-on(gh/rust-lang/crater/f190933e896443e285e3bb6962fb87d7439b8d65)"
         }
       ],
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/beta-faulty-deps"
@@ -171,11 +171,11 @@
       "runs": [
         {
           "log": "stable/local/faulty-deps",
-          "res": "build-fail:unknown"
+          "res": "build-fail:depends-on(reg/lazy_static/0.1.0, gh/rust-lang/crater/c3f462bdab37a93c24b2b172b90564749e892cbc)"
         },
         {
           "log": "beta/local/faulty-deps",
-          "res": "build-fail:unknown"
+          "res": "build-fail:depends-on(reg/lazy_static/0.1.0, gh/rust-lang/crater/c3f462bdab37a93c24b2b172b90564749e892cbc)"
         }
       ],
       "url": "https://github.com/rust-lang/crater/tree/master/local-crates/faulty-deps"


### PR DESCRIPTION
I [noticed](https://github.com/rust-lang/rust/pull/134272#issuecomment-2551634242) that a lot of errors that I would expect to be categorized as `DependsOn(_)` would end up as `Unknown` instead.

It looks like cargo sets the `package_id` field in the json output to `registry+https://github.com/rust-lang/crates.io-index#{crate_name}@{crate_version}` which wan't handled by `Crate::try_from`.
As a result no crate would be inserted into the `deps` set and it wasn't able to differentiate between an empty `deps` set due to no errors in dependencies and an empty `deps` set because the `package_id`s field of failing deps couldn't be parsed into a `Crate`.