### PR TITLE
follow up to rust-lang/crater#760, fix parsing FailureReason::Docker from string

### DIFF
--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -272,6 +272,7 @@ impl ::std::str::FromStr for FailureReason {
                 "timeout" => Ok(FailureReason::Timeout),
                 "ice" => Ok(FailureReason::ICE),
                 "no-space" => Ok(FailureReason::NoSpace),
+                "docker" => Ok(FailureReason::Docker),
                 _ => bail!("unexpected value: {}", s),
             }
         }

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -356,6 +356,7 @@ mod tests {
         //"build-fail:depends-on()" => BuildFail(DependsOn(vec!["001"])),
         test_from_str! {
             "build-fail:unknown" => BuildFail(Unknown),
+            "build-fail:docker" => BuildFail(Docker),
             "build-fail:compiler-error(001, 002)" => BuildFail(CompilerError(btreeset!["001".parse().unwrap(), "002".parse().unwrap()])),
             "build-fail:compiler-error(001)" => BuildFail(CompilerError(btreeset!["001".parse().unwrap()])),
             "build-fail:oom" => BuildFail(OOM),


### PR DESCRIPTION
I noticed that the crater run https://github.com/rust-lang/rust/issues/135511#issuecomment-2594786989 had no spurious-regressions due to docker. Turns out in rust-lang/crater#760 I forgot to update the parsing of `FailureReason` after adding the `Docker` variant.