### PR TITLE
reclassify prepare failure

### DIFF
--- a/src/report/display.rs
+++ b/src/report/display.rs
@@ -58,6 +58,7 @@ impl ResultName for TestResult {
     fn short_name(&self) -> String {
         match self {
             TestResult::BrokenCrate(reason) => reason.short_name(),
+            TestResult::PrepareFail(reason) => format!("prepare {}", reason.short_name()),
             TestResult::BuildFail(reason) => format!("build {}", reason.short_name()),
             TestResult::TestFail(reason) => format!("test {}", reason.short_name()),
             TestResult::TestSkipped => "test skipped".into(),
@@ -69,6 +70,7 @@ impl ResultName for TestResult {
 
     fn long_name(&self) -> String {
         match self {
+            TestResult::PrepareFail(reason) => format!("prepare {}", reason.long_name()),
             TestResult::BuildFail(reason) => format!("build {}", reason.long_name()),
             TestResult::TestFail(reason) => format!("test {}", reason.long_name()),
             TestResult::BrokenCrate(reason) => reason.long_name(),
@@ -103,6 +105,7 @@ impl ResultColor for Comparison {
             Comparison::SameTestPass => Color::Single("#72a156"),
             Comparison::Error => Color::Single("#d77026"),
             Comparison::Broken => Color::Single("#44176e"),
+            Comparison::PrepareFail => Color::Striped("#44176e", "#d77026"),
             Comparison::SpuriousRegressed => Color::Striped("#db3026", "#d5433b"),
             Comparison::SpuriousFixed => Color::Striped("#5630db", "#5d3dcf"),
         }
@@ -117,6 +120,7 @@ impl ResultColor for TestResult {
             TestResult::TestFail(_) => Color::Single("#65461e"),
             TestResult::TestSkipped | TestResult::TestPass => Color::Single("#62a156"),
             TestResult::Error => Color::Single("#d77026"),
+            TestResult::PrepareFail(_) => Color::Striped("#44176e", "#d77026"),
             TestResult::Skipped => Color::Single("#494b4a"),
         }
     }

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -307,6 +307,7 @@ string_enum!(pub enum BrokenReason {
 test_result_enum!(pub enum TestResult {
     with_reason {
         BrokenCrate(BrokenReason) => "broken",
+        PrepareFail(FailureReason) => "prepare-fail",
         BuildFail(FailureReason) => "build-fail",
         TestFail(FailureReason) => "test-fail",
     }
@@ -356,6 +357,11 @@ mod tests {
 
         //"build-fail:depends-on()" => BuildFail(DependsOn(vec!["001"])),
         test_from_str! {
+            "prepare-fail:unknown" => PrepareFail(Unknown),
+            "prepare-fail:oom" => PrepareFail(OOM),
+            "prepare-fail:docker" => PrepareFail(Docker),
+            "prepare-fail:no-space" => PrepareFail(NoSpace),
+            "prepare-fail:timeout" => PrepareFail(Timeout),
             "build-fail:unknown" => BuildFail(Unknown),
             "build-fail:docker" => BuildFail(Docker),
             "build-fail:compiler-error(001, 002)" => BuildFail(CompilerError(btreeset!["001".parse().unwrap(), "002".parse().unwrap()])),

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -15,7 +15,7 @@ use rustwide::{Build, PrepareError};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::ErrorKind;
 
-fn failure_reason(err: &Error) -> FailureReason {
+pub(crate) fn failure_reason(err: &Error) -> FailureReason {
     if let Some(reason) = err.downcast_ref::<FailureReason>() {
         reason.clone()
     } else if let Some(command_error) = err.downcast_ref::<CommandError>() {

--- a/src/runner/worker.rs
+++ b/src/runner/worker.rs
@@ -4,7 +4,7 @@ use crate::experiments::{Experiment, Mode};
 use crate::prelude::*;
 use crate::results::{BrokenReason, TestResult};
 use crate::runner::tasks::{Task, TaskStep};
-use crate::runner::test::detect_broken;
+use crate::runner::test::{detect_broken, failure_reason};
 use crate::runner::OverrideResult;
 use crate::toolchain::Toolchain;
 use crate::utils;
@@ -244,7 +244,7 @@ impl<'a> Worker<'a> {
                 let mut result = if self.config.is_broken(&krate) {
                     TestResult::BrokenCrate(BrokenReason::Unknown)
                 } else {
-                    TestResult::Error
+                    TestResult::PrepareFail(failure_reason(&err))
                 };
 
                 if let Some(OverrideResult(res)) = err.downcast_ref() {


### PR DESCRIPTION
Currently prepare failure gets classified as `Error` unless the crate is determined to be broken in which case its classified as `Broken`. This PR reclassifies the former.

Most if not all of the perpare errors are spurious and would benefit from being included in the `retry-regressed-list.txt` so that they can be retried.

This should cause instances such as <https://crater-reports.s3.amazonaws.com/beta-1.86-rustdoc-1/1.85.0/reg/ssstar-0.7.3/log.txt> to be classified as prepare-fail instead of error which means the are included in the retry-regressed-list.txt and have a change at properly regressing in a retry.

This should help prevent [regression in beta crater run being missed](https://github.com/rust-lang/rust/issues/139542#issuecomment-2794397767) due to running out of disk space as was the case with the above example.


The first commit fixes existing clippy problems.

The second commit removes a no longer existing crate from the config.toml (broke config check)

The third commit cleans-up the compare match. 
Basically a regression is spurious if the test toolchain result is spurious
and a fix is spurious if the base toolchain result is spurious.
This only changes the classification of  `BuildFail(non-spurious) -> TestFail(spurious)` from `SpuriousFixed` to `Fixed`.
I think the new classification is correct and the old one was wrong.

The fourth commit adds a new `Comparison` and `TestResult` variant to properly classify the failure mode of preparation failing for a non-broken crate. 
It also adds crates with this new Comparison variant to the `retry-regressed-list.txt`.

I expect this to significantly increase the size of the `retry-regressed-list.txt`.

Edit: Including `PrepareFail` in the `retry-regressed-list.txt` makes the file a bit misnamed, maybe it should be renamed to `retry-list.txt` the function for filtering the crates `gen_retry_list` already doesn't contain regressed in its name.


