### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/bin/test-report.rs
+++ b/src/bin/test-report.rs
@@ -79,6 +79,6 @@ impl ReportWriter for NullWriter {
 
 impl fmt::Display for NullWriter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -60,7 +60,7 @@ impl<E: std::error::Error> r2d2::HandleError<E> for ErrorHandler {
         if log::log_enabled!(log::Level::Error) {
             log::error!("r2d2 error: {:?}", error);
         } else {
-            eprintln!("r2d2 error: {:?}", error);
+            eprintln!("r2d2 error: {error:?}");
         }
     }
 }

--- a/src/report/archives.rs
+++ b/src/report/archives.rs
@@ -51,7 +51,7 @@ impl Drop for TempfileBackedBuffer {
     fn drop(&mut self) {
         unsafe {
             if let Err(e) = nix::sys::mman::munmap(self.mmap.as_ptr() as *mut _, self.mmap.len()) {
-                eprintln!("Failed to unmap temporary file: {:?}", e);
+                eprintln!("Failed to unmap temporary file: {e:?}");
             }
         }
     }

--- a/src/runner/worker.rs
+++ b/src/runner/worker.rs
@@ -256,11 +256,8 @@ impl<'a> Worker<'a> {
                         self.ex,
                         &krate,
                         tc,
-                        format!(
-                            "{}\n\nthis task or one of its parent failed: {:?}",
-                            logs, err
-                        )
-                        .as_bytes(),
+                        format!("{logs}\n\nthis task or one of its parent failed: {err:?}")
+                            .as_bytes(),
                         &result,
                         updated_version.as_ref().map(|new| (&krate, new)),
                     ) {
@@ -327,7 +324,7 @@ impl<'a> Worker<'a> {
                             self.ex,
                             &task.krate,
                             tc,
-                            format!("{}\n\n{:?}", storage, err).as_bytes(),
+                            format!("{storage}\n\n{err:?}").as_bytes(),
                             &test_result,
                             updated_version.as_ref().map(|new| (&krate, new)),
                         )?;

--- a/src/server/routes/ui/experiments.rs
+++ b/src/server/routes/ui/experiments.rs
@@ -131,7 +131,7 @@ fn humanize(duration: Duration) -> String {
         Ok(d) => d,
         Err(_) => {
             // Don't try to make it pretty as a fallback.
-            return format!("{:?}", duration);
+            return format!("{duration:?}");
         }
     };
     if duration.as_secs() < 60 {


### PR DESCRIPTION
This fixes the clippy::uninlined_format_args lint which looks like it was moved to "style" in https://github.com/rust-lang/rust-clippy/pull/14160.