### PR TITLE
don't ping infra team on errors

### DIFF
--- a/src/server/reports.rs
+++ b/src/server/reports.rs
@@ -84,7 +84,7 @@ fn reports_thread(data: &Data, github_data: Option<&GithubData>) -> Fallible<()>
                         )
                         .note(
                             "sos",
-                            "Can someone from the infra team check in on this? @rust-lang/infra",
+                            "If you need assistance dealing with this failure, please ask in [t-infra](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra) on Zulip",
                         )
                         .send(&github_issue.api_url, data, github_data)?;
                     }

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -58,7 +58,7 @@ fn process_webhook(
                     .line("rotating_light", format!("**Error:** {e}"))
                     .note(
                         "sos",
-                        "If you have any trouble with Crater please ping **`@rust-lang/infra`**!",
+                        "If you have any trouble with Crater please ask in [t-infra](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra) on Zulip",
                     )
                     .send(&p.issue.url, data, github_data)?;
             }


### PR DESCRIPTION
Discussed in [zulip]([#t-infra > removing team ping on crater failures](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/removing.20team.20ping.20on.20crater.20failures/with/517576152))