### PR TITLE
Add a new "fix" mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ remove_dir_all = "0.7"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rusqlite = { version = "0.32.1", features = ["chrono", "functions", "bundled"] }
 rust_team_data = { git = "https://github.com/rust-lang/team" }
-rustwide = { version = "0.19.1", features = [
+rustwide = { version = "0.19.3", features = [
     "unstable",
     "unstable-toolchain-ci",
 ] }

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -85,6 +85,7 @@ The following experiment modes are currently available:
 * `check-only`: run `cargo check` on every crate (faster)
 * `clippy`: run `cargo clippy` on every crate
 * `rustdoc`: run `cargo doc --no-deps` on every crate
+* `fix`: run `cargo fix` on every crate (intended for edition migration testing)
 
 The mode you should use depends on what your experiment is testing:
 

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -30,6 +30,7 @@ string_enum!(pub enum Mode {
     Clippy => "clippy",
     Rustdoc => "rustdoc",
     UnstableFeatures => "unstable-features",
+    Fix => "fix",
 });
 
 string_enum!(pub enum CapLints {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -300,7 +300,7 @@ fn write_logs<DB: ReadResults, W: ReportWriter>(
         }
 
         for (i, krate) in crates.iter().enumerate() {
-            if i % progress_every == 0 {
+            if i.is_multiple_of(progress_every) {
                 info!("wrote logs for {i}/{num_crates} crates")
             }
 

--- a/src/runner/tasks.rs
+++ b/src/runner/tasks.rs
@@ -48,6 +48,7 @@ pub(super) enum TaskStep {
     Clippy { tc: Toolchain, quiet: bool },
     Rustdoc { tc: Toolchain, quiet: bool },
     UnstableFeatures { tc: Toolchain },
+    Fix { tc: Toolchain, quiet: bool },
 }
 
 impl fmt::Debug for TaskStep {
@@ -59,6 +60,7 @@ impl fmt::Debug for TaskStep {
             TaskStep::Clippy { ref tc, quiet } => ("clippy", quiet, Some(tc)),
             TaskStep::Rustdoc { ref tc, quiet } => ("doc", quiet, Some(tc)),
             TaskStep::UnstableFeatures { ref tc } => ("find unstable features on", false, Some(tc)),
+            TaskStep::Fix { ref tc, quiet } => ("fix", quiet, Some(tc)),
         };
 
         write!(f, "{name}")?;
@@ -124,6 +126,7 @@ impl Task {
                 tc,
                 false,
             ),
+            TaskStep::Fix { ref tc, quiet } => (&build_dir[tc], "fixing", test::fix, tc, quiet),
         };
 
         let ctx = TaskCtx::new(build_dir, config, ex, toolchain, &self.krate, quiet);

--- a/src/runner/worker.rs
+++ b/src/runner/worker.rs
@@ -123,7 +123,8 @@ impl<'a> Worker<'a> {
                     | TaskStep::CheckOnly { tc, .. }
                     | TaskStep::Clippy { tc, .. }
                     | TaskStep::Rustdoc { tc, .. }
-                    | TaskStep::UnstableFeatures { tc } => Some(tc),
+                    | TaskStep::UnstableFeatures { tc }
+                    | TaskStep::Fix { tc, .. } => Some(tc),
                 };
                 if let Some(toolchain) = toolchain {
                     if toolchain == self.ex.toolchains.last().unwrap() {
@@ -301,6 +302,10 @@ impl<'a> Worker<'a> {
                             quiet,
                         },
                         Mode::UnstableFeatures => TaskStep::UnstableFeatures { tc: tc.clone() },
+                        Mode::Fix => TaskStep::Fix {
+                            tc: tc.clone(),
+                            quiet,
+                        },
                     },
                 };
 

--- a/src/server/routes/ui/experiments.rs
+++ b/src/server/routes/ui/experiments.rs
@@ -41,6 +41,7 @@ impl ExperimentData {
                 Mode::Clippy => "cargo clippy",
                 Mode::Rustdoc => "cargo doc",
                 Mode::UnstableFeatures => "unstable features",
+                Mode::Fix => "cargo fix",
             },
             assigned_to: experiment.assigned_to.as_ref().map(|a| a.to_string()),
             priority: experiment.priority,


### PR DESCRIPTION
This introduces a new "fix" mode to run `cargo fix`. This is primarily intended to support edition migration testing.

This includes two related changes:

- Adds the ability to change the CapLints behavior because setting CapLints interferes with how `cargo fix` works.
- Sets the mount mode of the source directory to read-write because `cargo fix` inherently needs to be able to write to the source directory.

It probably needs more work for general purpose `cargo fix` testing (non-edition) because otherwise it would need to rebuild the source directory between toolchains. I don't need that right now, so deferred that till later.

The edition testing is intended to work with [`cargo -Zfix-edition`](https://github.com/rust-lang/cargo/pull/15596) which performs the necessary actions to work in crater. More documentation (on the forge) will be coming once this is merged.
